### PR TITLE
ci:add github action yml configuration for automatical build & release android

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,29 @@
+name: build kantv
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        required: false
+        type: string
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          fetch-depth: '0'
+        
+      - name: build android
+        with:
+          path: ${{ github.workspace }}  
+        run: |
+          source build/envsetup.sh  
+          lunch 1  
+          ./build-all.sh android

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,15 @@ on:
   push:
     branches:
       - master
+     # 添加忽略路径，避免文档更新等触发构建
+    paths-ignore:     
+      - '**.md'
+      - 'docs/**'
+      - '.gitignore'
+  release:
+    types: [published]
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   build:
@@ -20,10 +29,28 @@ jobs:
           submodules: 'recursive'
           fetch-depth: '0'
         
-      - name: build android
-        with:
-          path: ${{ github.workspace }}  
+      - name: build android release
         run: |
           source build/envsetup.sh  
+          ./build/prebuild-download.sh  
           lunch 1  
           ./build-all.sh android
+
+      - name: upload arm64-v8a release
+        uses: actions/upload-artifact@v4
+        if: ${{  success() }}
+        with:
+          name: arm64-v8a release apk
+          compression-level: 0 
+          retention-days: 3
+          path: ${{ github.workspace }}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-release-*-signed.apk
+          
+      - name: upload arm64-v8a release to release
+        uses: svenstaro/upload-release-action@v2
+        if: github.event_name == 'release'
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-release-*-signed.apk
+          tag: ${{ github.ref }}
+          file_glob: true
+

--- a/build-all.sh
+++ b/build-all.sh
@@ -132,7 +132,7 @@ function build_kantv_apk()
 
         printf "succeed to build apk ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk by cmdline-tools\n"
         ls -lah ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk
-
+        sign_kantv_apk
         cd ${PROJECT_ROOT_PATH}
         echo ""
         echo ""
@@ -150,6 +150,49 @@ function build_kantv_apk()
     echo ""
     echo "------------------------------------------------------------------------------------------"
     echo ""
+}
+
+
+function sign_kantv_apk()
+{
+    declare -r KANTV_KEY_PASSWORD="123456"
+    declare -r KANTV_KEYSTORE_PASSWORD="123456"
+    declare -r KANTV_KEY_ALIAS="relase-keystore"
+    declare -r KANTV_KEY_VALIDITY=365
+
+    if ! command -v keytool || ! command -v jarsigner; then
+        echo "keytool or  jarsigner is not installed, pls install JDK first"
+        exit 1
+    fi
+    keytool -genkeypair \
+            -alias "$KANTV_KEY_ALIAS" \
+            -keyalg RSA \
+            -keysize 2048 \
+            -validity "$KANTV_KEY_VALIDITY" \
+            -keystore "${PROJECT_ROOT_PATH}/kantv.jks" \
+            -storepass "$KANTV_KEYSTORE_PASSWORD" \
+            -keypass "$KANTV_KEY_PASSWORD" \
+            -dname "CN=kantv authors, OU=kantv, O=kantv, L=China, ST=China, C=China"
+    #check whether jks file is generated
+    if [ -f "${PROJECT_ROOT_PATH}/kantv.jks" ]; then
+        echo "succeed to generate keystore ${PROJECT_ROOT_PATH}/kantv.jks"
+    else
+        echo "failed to generate keystore ${PROJECT_ROOT_PATH}/kantv.jks"
+        exit 1
+    fi
+    #sign apk
+    jarsigner -verbose -keystore "${PROJECT_ROOT_PATH}/kantv.jks" \
+              -storepass "$KANTV_KEYSTORE_PASSWORD" \
+              -keypass "$KANTV_KEY_PASSWORD" "${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk" "$KANTV_KEY_ALIAS" \
+              -signedjar "${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-signed.apk"
+
+    if [ $? -ne 0 ]; then
+        echo -e "${TEXT_RED}failed to sign apk,you may need to sign it mannually${TEXT_RESET}" 
+        echo "unsigned apk located in:${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk" 
+        exit 1
+    else
+        echo -e "${TEXT_GREEN}succeed to sign apk: ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-signed.apk${TEXT_RESET}"  
+    fi                
 }
 
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -130,8 +130,8 @@ function build_kantv_apk()
         #printf "succeed to build apk ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/debug/kantv-all64-debug.apk by cmdline-tools\n"
         #ls -lah ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/debug/kantv-all64-debug.apk
 
-        printf "succeed to build apk ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk by cmdline-tools\n"
-        ls -lah ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk
+        printf "succeed to build apk in dir:${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release by cmdline-tools\n"
+        ls -lah ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/*.apk
         sign_kantv_apk
         cd ${PROJECT_ROOT_PATH}
         echo ""
@@ -183,15 +183,15 @@ function sign_kantv_apk()
     #sign apk
     jarsigner -verbose -keystore "${PROJECT_ROOT_PATH}/kantv.jks" \
               -storepass "$KANTV_KEYSTORE_PASSWORD" \
-              -keypass "$KANTV_KEY_PASSWORD" "${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk" "$KANTV_KEY_ALIAS" \
-              -signedjar "${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-signed.apk"
+              -keypass "$KANTV_KEY_PASSWORD" "${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-${PROJECT_BUILD_TYPE}-v${ANDROID_APK_VERSION}-unsigned.apk" "$KANTV_KEY_ALIAS" \
+              -signedjar "${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-${PROJECT_BUILD_TYPE}-v${ANDROID_APK_VERSION}-signed.apk"
 
     if [ $? -ne 0 ]; then
         echo -e "${TEXT_RED}failed to sign apk,you may need to sign it mannually${TEXT_RESET}" 
-        echo "unsigned apk located in:${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-unsigned.apk" 
+        echo "unsigned apk located in:${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release" 
         exit 1
     else
-        echo -e "${TEXT_GREEN}succeed to sign apk: ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-all64-release-signed.apk${TEXT_RESET}"  
+        echo -e "${TEXT_GREEN}succeed to sign apk: ${PROJECT_ROOT_PATH}/cdeosplayer/kantv/build/outputs/apk/all64/release/kantv-${PROJECT_BUILD_TYPE}-v${ANDROID_APK_VERSION}-signed.apk${TEXT_RESET}"  
     fi                
 }
 

--- a/build/envsetup.sh
+++ b/build/envsetup.sh
@@ -83,6 +83,7 @@ export NDK_ROOT=${ANDROID_NDK}          # make some open source project happy
 export PATH=${ANDROID_NDK_ROOT}:${PATH}
 
 export ANDROID_HOME=${PROJECT_ROOT_PATH}/prebuilts/toolchain/android-sdk
+export ANDROID_SDK_ROOT=${ANDROID_HOME} # build with github actions, this is required
 export PATH=${ANDROID_HOME}/cmdline-tools/latest/bin:${PATH}
 export PATH=${ANDROID_HOME}/cmake/3.22.1/bin:${PATH}
 

--- a/build/public.sh
+++ b/build/public.sh
@@ -29,6 +29,7 @@ if [ "${BUILD_TARGET}" == "android" ]; then
     export BUILD_ARCHS="arm64-v8a"
     export FF_PREFIX=${PROJECT_OUT_PATH}/${BUILD_TARGET}/
     export PROJECT_BUILD_COMMAND="./build-all.sh android"
+    export ANDROID_APK_VERSION=$(awk -F"'" '/releaseVersion[ ]*=/ {print $2}' "${PROJECT_ROOT_PATH}/cdeosplayer/constants.gradle")
 fi
 
 if [ "${BUILD_TARGET}" == "linux" ]; then

--- a/cdeosplayer/.gitignore
+++ b/cdeosplayer/.gitignore
@@ -3,7 +3,6 @@
 /.idea/workspace.xml
 /.idea/libraries
 .DS_Store
-/build
 /buildout
 /captures
 android-ndk-prof

--- a/cdeosplayer/kantv/build.gradle
+++ b/cdeosplayer/kantv/build.gradle
@@ -30,6 +30,11 @@ android {
 
         //fix conflict between open source native libs and prebuilt proprietary native libs(IDE would complain more than one file was found)
         packagingOptions {
+            //native libs packing,leagcy mode is used for better compatibility
+            jniLibs {
+                useLegacyPackaging = true
+            }
+        
             pickFirst 'lib/arm64-v8a/libkantv-media.so'
             //pickFirst 'lib/arm64-v8a/libkantv-ffmpeg.so'
             pickFirst 'lib/arm64-v8a/libggml-jni.so'
@@ -91,6 +96,12 @@ android {
         }
     }
 
+    //FranzKafka:2025-02-22, add version/compiletime in apk name
+    applicationVariants.all { variant ->
+        variant.outputs.all {
+            outputFileName = "kantv-${variant.buildType.name}-v${project.ext.releaseVersion}-unsigned.apk"
+        }
+    }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8


### PR DESCRIPTION
1.automatic sign apk after build release  
original code base won't sign apk automatically,so developers & users may need sign apk mannually,so I add a function in `build-all.sh`,named `sign_kantv_apk`,this can sign apk automatically.we can get the signed apk like this:  
```  
-rw-rw-r-- 1 franzkafka franzkafka  97M  2月 22 15:58 kantv-release-v1.3.11-signed.apk
-rw-rw-r-- 1 franzkafka franzkafka 101M  2月 22 15:57 kantv-release-v1.3.11-unsigned.apk
```    
NOTICE:current we will generate a new jks when there no existed jks file,which will cause unmatched signature,and if we have installed `kantv` apk before,we may need uninstall it first.The only solution is we need a built-in jks file and we configure it in `build.gradle`,gradle will help us sign the apk with the built-in jks file.   

2.apk named with build type and release version  
I modified `build.gradle` for a better name of the output apk,with its version code.    

3.export ANDROID_APK_VERSION for build  
this is needed when we sign the apk.  

4.add github action yml configuration  

In short,this configuration will help us:  
- automatical build there are pr or push in master  
- if we build successfully,we will get the output in Artifacts,check [this](https://github.com/FranzKafkaYu/kantv/actions/runs/13471588303)  
- if we create a release,will triger build and upload the signed apk in release,check [this](https://github.com/FranzKafkaYu/kantv/releases/tag/0.0.2)     

when I debug this in github action,I have found that github action runner will export ANDROID_SDK_ROOT env,which will cause dumplicated SDK path,so I export this env in `envsetup.sh`  to address this problem.  

5.remove build dir from .gitignore  
I have made some changes in `public.sh`,someone may do this too,so it's better.