### PR TITLE
stability: fix issue of AI-subtitle which introduced in https://github.com/kantv-ai/kantv/pull/281

### DIFF
--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/player/ffplayer/FFPlayerView.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/player/ffplayer/FFPlayerView.java
@@ -1574,12 +1574,21 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
         }
 
         if (KANTVUtils.getASRSubsystemInit()) {
+            int result = 0;
             if ((KANTVUtils.ASR_MODE_NORMAL == mSettings.getASRMode()) || (KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD == mSettings.getASRMode())) {
-                ggmljava.asr_reset(KANTVUtils.getDataPath() + "/models/" + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
+                result = ggmljava.asr_reset(KANTVUtils.getDataPath() + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
             } else {
-                ggmljava.asr_reset(KANTVUtils.getDataPath() + "/models/" + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_PRESURETEST, ggmljava.HEXAGON_BACKEND_GGML);
+                result = ggmljava.asr_reset(KANTVUtils.getDataPath() + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_PRESURETEST, ggmljava.HEXAGON_BACKEND_GGML);
             }
-            ggmljava.asr_start();
+            if (0 == result) {
+                ggmljava.asr_start();
+            } else {
+                KANTVLog.j(TAG, "failed to initialized ASR");
+                topBarView.updateTVASRVisibility(false);
+                KANTVUtils.setTVASR(false);
+                KANTVUtils.showMsgBox(mAttachActivity, "ASR subsystem not initialized, pls check why");
+                return;
+            }
         } else {
             topBarView.updateTVASRVisibility(false);
             KANTVUtils.setTVASR(false);

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/AIResearchFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/AIResearchFragment.java
@@ -559,7 +559,12 @@
              ggmlModelFileName = selectModelFilePath;
              KANTVLog.j(TAG, "model file:" + selectModelFilePath);
              if (isASRModel) { //avoid crash
-                 ggmljava.asr_reset(selectModelFilePath, ggmljava.get_cpu_core_counts() / 2, KANTVUtils.ASR_MODE_BECHMARK, backendIndex);
+                 int result = ggmljava.asr_reset(selectModelFilePath, ggmljava.get_cpu_core_counts() / 2, KANTVUtils.ASR_MODE_BECHMARK, backendIndex);
+                 if (0 != result) {
+                     KANTVLog.j(TAG, "failed to initialize ASR");
+                     KANTVUtils.showMsgBox(mActivity, "failed to initialize ASR");
+                     return;
+                 }
              }
 
              nLogCounts = 0;

--- a/core/ggml/jni/ggml-jni-impl.cpp
+++ b/core/ggml/jni/ggml-jni-impl.cpp
@@ -635,7 +635,7 @@ static const char * ggml_jni_transcribe_from_file(const char * sz_model_path, co
         wcp.gpu_device  = n_backend_type;
         wcp.use_gpu     = false;
 #ifdef GGML_USE_HEXAGON
-        if (n_backend_type != 1) {
+        if (n_backend_type != HEXAGON_BACKEND_GGML) {
             wcp.use_gpu = true;
         } else {
             wcp.use_gpu = false;
@@ -1457,7 +1457,7 @@ int whisper_asr_init(const char * sz_model_path, int n_threads, int n_asrmode, i
      c_params.gpu_device  = n_backend;
      c_params.use_gpu     = false;
 #ifdef GGML_USE_HEXAGON
-     if (n_backend != 1) {
+     if (n_backend != HEXAGON_BACKEND_GGML) {
          c_params.use_gpu = true;
      } else {
          c_params.use_gpu = false;
@@ -1643,7 +1643,7 @@ int whisper_asr_reset(const char * sz_model_path, int n_threads, int n_asrmode, 
         wcp.gpu_device  = n_backend;
         wcp.use_gpu     = false;
 #ifdef GGML_USE_HEXAGON
-        if (n_backend != 1) {
+        if (n_backend != HEXAGON_BACKEND_GGML) {
             wcp.use_gpu = true;
         } else {
             wcp.use_gpu = false;
@@ -1661,7 +1661,21 @@ int whisper_asr_reset(const char * sz_model_path, int n_threads, int n_asrmode, 
         wcp.gpu_device  = n_backend;
         wcp.use_gpu     = false;
 #ifdef GGML_USE_HEXAGON
-        if (n_backend != 1) {
+        if (n_backend != HEXAGON_BACKEND_GGML) {
+            wcp.use_gpu = true;
+        } else {
+            wcp.use_gpu = false;
+        }
+#endif
+        p_asr_ctx->p_context = whisper_init_from_file_with_params(sz_model_path, wcp);
+        p_asr_ctx->n_backend = n_backend;
+    } else if (nullptr == p_asr_ctx->p_context) {
+        LOGGD("re-init whispercpp instance");
+        struct whisper_context_params wcp = whisper_context_default_params();
+        wcp.gpu_device  = n_backend;
+        wcp.use_gpu     = false;
+#ifdef GGML_USE_HEXAGON
+        if (n_backend != HEXAGON_BACKEND_GGML) {
             wcp.use_gpu = true;
         } else {
             wcp.use_gpu = false;
@@ -1674,6 +1688,7 @@ int whisper_asr_reset(const char * sz_model_path, int n_threads, int n_asrmode, 
     }
 
     if (nullptr == p_asr_ctx->p_context) {
+        LOGGW("it should not happen and ASR feature would be not available, pls check why?\n");
         result = 3;
     } else {
         p_asr_ctx->n_threads            = n_threads;

--- a/core/ggml/whispercpp/whisper.cpp
+++ b/core/ggml/whispercpp/whisper.cpp
@@ -1282,11 +1282,13 @@ static ggml_backend_t whisper_backend_init_gpu(const whisper_context_params & pa
 static std::vector<ggml_backend_t> whisper_backend_init(const whisper_context_params & params) {
     std::vector<ggml_backend_t> result;
 
+#if 0 //forcefully disable ggml-hexagon backend because there is unknown issue with ASR inference through cDSP, refer to:https://github.com/kantv-ai/kantv/pull/281
     ggml_backend_t backend_gpu = whisper_backend_init_gpu(params);
 
     if (backend_gpu) {
         result.push_back(backend_gpu);
     }
+
 
     // ACCEL backends
     for (size_t i = 0; i < ggml_backend_dev_count(); ++i) {
@@ -1305,7 +1307,7 @@ static std::vector<ggml_backend_t> whisper_backend_init(const whisper_context_pa
             result.push_back(backend);
         }
     }
-
+#endif
     GGML_UNUSED(params);
 
     result.push_back(ggml_backend_cpu_init());


### PR DESCRIPTION
### Purpose
AI-subtitle can't works(APP would crash when launch AI-subtitle during playback on-line TV) because of big changes in https://github.com/kantv-ai/kantv/pull/281

### Status

validate following features on Android phone equipped with Snapdragon 8Gen3 and Snapdragon 8Elite:
- TV playback
- TV playback + TV recording
- local playback with recorded video file
- TV playback +  AI-subtitle
- TV playback + TV recording + AI-subtitle
- ASR inference(through whisper.cpp) benchmark with ggml backend
- LLM inference(through llama.cpp) benchmark with ggml  backend and cDSP backend
- 2D graphic benchmark
- video encode benchmark
- video encode benchmark and create code-generated video file
- local playback with code-generated video file

### Todo

an automated CT approach should be introduced in this project for validate every PR. whether AI can be used for this purpose?