### PR TITLE
ui: add LLM setting and download LLM model in APK

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,35 +43,18 @@ As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon
 ### Building the project
 
 - Clone this repository and build locally, see [how to build](./docs/build.md)
-- How to build project for Android phone equipped <b>without</b> Qualcomm mobile SoC:modify [ggml/CMakeLists.txt#L12](./core/ggml/CMakeLists.txt#L12) accordingly.
 - Download pre-built Android APK from https://github.com/kantv-ai/kantv/releases
 
 ### Run Android APK on Android phone
-
-- Prepare LLM model
-```
-    wget https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q8_0.gguf
-
-    adb push gemma-3-4b-it-Q8_0.gguf /sdcard/
-```
-
 - Android smartphone equipped with one of below Qualcomm mobile SoCs(Qualcomm Snapdragon 8Gen3 and Snapdragon 8Elite are highly recommended) is <b>required</b> for verify/running ggml-hexagon backend on Android phone:
-
+```
     Snapdragon 8 Gen 1
-
     Snapdragon 8 Gen 1+
-
     Snapdragon 8 Gen 2
-
     Snapdragon 8 Gen 3
-
     Snapdragon 8 Elite
-
+```
 - Android smartphone equipped with <b>ANY</b> mainstream high-end mobile SoC is highly <b>recommented</b> for realtime AI-subtitle feature otherwise unexpected behavior would happen
-
-- This project is a <b>pure AI learning&study</b> project, so the Android APK is a <b>green</b> Android APP and will <b>NOT</b> collect/upload user data in Android device, following minimum permissions are required:
-  - Access to storage is required for TV recording(write recording data to storage) and ASR/LLM inference(read/load models from storage)
-  - Access to device information is required to obtain phone's network status information, distinguishing whether the current network is Wi-Fi or mobile when playing online TV
 
 ### Screenshots
 <hr>
@@ -81,28 +64,35 @@ https://github.com/zhouwg/kantv/assets/6889919/2fabcb24-c00b-4289-a06e-05b98ecd2
 
 ----
 
-here is a screenshot to demostrate multi-modal inference by running the magic <a href="https://github.com/ggerganov/llama.cpp"> llama.cpp </a> on an Android phone equipped with Qualcomm Snapdragon 8 Gen3 mobile SoC  - <b>fully offline, on-device</b>.
+a screenshot to demostrate multi-modal inference by running the magic <a href="https://github.com/ggerganov/llama.cpp"> llama.cpp </a> on an Android phone equipped with Qualcomm Snapdragon 8 Gen3 mobile SoC  - <b>fully offline, on-device</b>.
 
 
 ![1429485556](https://github.com/user-attachments/assets/84d9fed1-e250-4212-8eff-104f08110875)
 
 ----
-here is a screenshot to demostrate LLM inference by running the magic <a href="https://github.com/ggerganov/llama.cpp"> llama.cpp </a> on an Android phone equipped with Qualcomm Snapdragon 8 Gen3 mobile SoC  - <b>fully offline, on-device</b>.
+a screenshot to demostrate LLM inference by running the magic <a href="https://github.com/ggerganov/llama.cpp"> llama.cpp </a> on an Android phone equipped with Qualcomm Snapdragon 8 Gen3 mobile SoC  - <b>fully offline, on-device</b>.
 
 ![1351701335](https://github.com/user-attachments/assets/fc30d262-def2-4b77-973c-b71b33080535)
 
 
 ----
 
-here is a screenshot to demostrate ASR inference by running the excellent <a href="https://github.com/ggerganov/whisper.cpp"> whisper.cpp </a> on an Android phone equipped with Qualcomm Snapdragon 8 Gen 3 mobile SoC - <b>fully offline, on-device</b>.
+a screenshot to demostrate ASR inference by running the excellent <a href="https://github.com/ggerganov/whisper.cpp"> whisper.cpp </a> on an Android phone equipped with Qualcomm Snapdragon 8 Gen 3 mobile SoC - <b>fully offline, on-device</b>.
 
 ![705759462](https://github.com/user-attachments/assets/df1ed1ed-294e-4691-bbd1-b8a6f7ff6f8c)
+
+----
+a screenshot to demostrate download LLM model in APK.
+
+![Image](https://github.com/user-attachments/assets/b07f8560-9221-4136-b773-4b0874de294a)
+
 <details>
   <summary>some other screenshots</summary>
   <ol>
 
 ![Image](https://github.com/user-attachments/assets/2d95bd5e-bd02-4810-aa70-a81cc0469fcc)
 
+![Image](https://github.com/user-attachments/assets/025a8ff0-7584-4df2-97a5-f4e655a52e0f)
   </ol>
 </details>
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KanTV
 
-KanTV("Kan", aka English "watch") , an open source project focus on study and practise state-of-the-art device-AI technology in <b>real scenario</b>(such as online-TV playback and online-TV transcriptionand online-TV video&audio recording at the same time) on <b>ANY mainstream</b> Android phone/device:
+KanTV("Kan", aka English "watch") , an open source project focus on study and practise device-AI technology in <b>real scenario</b>(such as online-TV playback and <b>realtime transcription</b> through the amazing <b>whisper.cpp</b> and online-TV recording at the same time) on Android phone:
 
 
 - Watch online TV and local media by customized ![FFmpeg 6.1](https://github.com/zhouwg/FFmpeg). this project is derived from original ![ijkplayer](https://github.com/zhouwg/kantv/tree/kantv-initial)(because that project has stopped maintenance since 2021), with much enhancements and new features, source code of customized FFmpeg 6.1 could be found in <a href="https://github.com/zhouwg/kantv/tree/master/external/ffmpeg-6.1"> external/ffmpeg </a>according to <a href="https://ffmpeg.org/legal.html">FFmpeg's license</a>. Developers or domain tech experts can set up [a customized playlist](./android/kantvplayer/src/main/assets/tv.xml) and then use this software to watch the content of the customized playlist for R&D activity.
@@ -32,7 +32,7 @@ In the all, generally speaking,
 
 ### Highlight
 
-As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon/discussions/18"> the first open-source implementation of ggml-hexagon backend in llama.cpp community </a> for Android phone equipped with Qualcomm's high-end Hexagon NPU(such as Snapdragon 8Gen3/Snapdragon 8Elite), [PR can be found at upstream llama.cpp community](https://github.com/ggml-org/llama.cpp/pull/12326).
+As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon/discussions/18"> the first open-source implementation </a> of ggml-hexagon backend in llama.cpp community for Android phone equipped with Qualcomm's high-end Hexagon NPU(such as Snapdragon 8Gen3/Snapdragon 8Elite), [PR can be found at](https://github.com/ggml-org/llama.cpp/pull/12326) upstream llama.cpp community.
 
 
 ### Software architecture of KanTV Android
@@ -46,7 +46,7 @@ As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon
 - Download pre-built Android APK from https://github.com/kantv-ai/kantv/releases
 
 ### Run Android APK on Android phone
-- Android smartphone equipped with one of below Qualcomm mobile SoCs(Qualcomm Snapdragon 8Gen3 and Snapdragon 8Elite are highly recommended) is <b>required</b> for verify/running ggml-hexagon backend on Android phone:
+- Android smartphone equipped with one of below Qualcomm mobile SoCs(<b>Qualcomm high-end mobile SoC</b> Snapdragon 8Gen3 and Snapdragon 8Elite are highly recommended) is <b>required</b> for verify/running ggml-hexagon backend on Android phone:
 ```
     Snapdragon 8 Gen 1
     Snapdragon 8 Gen 1+
@@ -54,7 +54,7 @@ As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon
     Snapdragon 8 Gen 3
     Snapdragon 8 Elite
 ```
-- Android smartphone equipped with <b>ANY</b> mainstream high-end mobile SoC is highly <b>recommented</b> for realtime AI-subtitle feature otherwise unexpected behavior would happen
+- Android smartphone equipped with <b>ANY</b> mainstream <b>high-end</b> mobile SoC is highly <b>recommented</b> for realtime AI-subtitle feature otherwise unexpected behavior would happen
 
 ### Screenshots
 <hr>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KanTV
 
-KanTV("Kan", aka Chinese PinYin "Kan" or Chinese HanZi "看" or English "watch/listen") , an open source project focus on study and practise state-of-the-art device-AI technology in <b>real scenario</b>(such as online-TV playback and online-TV transcriptionand online-TV video&audio recording at the same time) on <b>ANY mainstream</b> Android phone/device:
+KanTV("Kan", aka English "watch") , an open source project focus on study and practise state-of-the-art device-AI technology in <b>real scenario</b>(such as online-TV playback and online-TV transcriptionand online-TV video&audio recording at the same time) on <b>ANY mainstream</b> Android phone/device:
 
 
 - Watch online TV and local media by customized ![FFmpeg 6.1](https://github.com/zhouwg/FFmpeg). this project is derived from original ![ijkplayer](https://github.com/zhouwg/kantv/tree/kantv-initial)(because that project has stopped maintenance since 2021), with much enhancements and new features, source code of customized FFmpeg 6.1 could be found in <a href="https://github.com/zhouwg/kantv/tree/master/external/ffmpeg-6.1"> external/ffmpeg </a>according to <a href="https://ffmpeg.org/legal.html">FFmpeg's license</a>. Developers or domain tech experts can set up [a customized playlist](./android/kantvplayer/src/main/assets/tv.xml) and then use this software to watch the content of the customized playlist for R&D activity.

--- a/README.md
+++ b/README.md
@@ -32,12 +32,12 @@ In the all, generally speaking,
 
 ### Highlight
 
-As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon/discussions/18"> the first open-source implementation of ggml-hexagon backend in llama.cpp community </a> for Android phone equipped with Qualcomm's high-end Hexagon NPU(such as Snapdragon 8Gen3/Snapdragon 8Elite).
+As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon/discussions/18"> the first open-source implementation of ggml-hexagon backend in llama.cpp community </a> for Android phone equipped with Qualcomm's high-end Hexagon NPU(such as Snapdragon 8Gen3/Snapdragon 8Elite), [PR can be found at upstream llama.cpp community](https://github.com/ggml-org/llama.cpp/pull/12326).
 
 
 ### Software architecture of KanTV Android
 
-![Image](https://github.com/user-attachments/assets/7dad3d8d-f938-4294-a8e3-3f4103e68bfa)
+![Image](https://github.com/user-attachments/assets/b82eda42-7211-4781-a7e5-7edb5bf60ed1)
 
 
 ### Building the project
@@ -115,6 +115,7 @@ Report issue in various Android-based phone and <b>submit PR to this project is 
 
 - [About ggml-hexagon](https://github.com/zhouwg/ggml-hexagon/discussions/18)
 - [How to build](./docs/build.md)
+- [How to troubleshooting](./docs/FAQ.md)
 - <b>[How to integrate proprietary/open source codes to project KanTV for personal/proprietary/commercial R&D activity](./docs/how-to-customize.md)</b>
 - [Authors](./AUTHORS)
 - [Acknowledgement](./docs/acknowledgement.md)

--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ As far as I/We know, probably be <a href="https://github.com/zhouwg/ggml-hexagon
 
 ### Software architecture of KanTV Android
 
-![Image](https://github.com/user-attachments/assets/b82eda42-7211-4781-a7e5-7edb5bf60ed1)
-
+![kantv-arch-320-240](https://github.com/user-attachments/assets/48e18ace-b667-45f9-8e0f-9faf1427e6bf)
 
 ### Building the project
 

--- a/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVLLMModel.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVLLMModel.java
@@ -22,13 +22,16 @@
 package kantvai.media.player;
 
 public class KANTVLLMModel {
+    private static final String TAG = KANTVLLMModel.class.getSimpleName();
     private int index;
-    private String nickname;    //short name
-    private String name;        //full name
+    private String nickname;    //model's short name
+    private String name;        //model's full name
     private String mmproj_name; //mmproj model name
-    private String url;     //original source
+    private String url;         //original url of model
 
-    private String quality; //quality on Android phone
+    private String mmproj_url;  //original url of mmproj model
+
+    private String quality;     //quality of model on Android phone
 
     public KANTVLLMModel(int index, String nick, String name, String url) {
         this.index = index;
@@ -45,6 +48,7 @@ public class KANTVLLMModel {
     public KANTVLLMModel(int index, String nick, String name, String mmprojName, String url, String quality) {
         this(index, nick, name, url, quality);
         this.mmproj_name = mmprojName;
+        KANTVLog.j(TAG, "init");
     }
 
     public String getNickname() { return nickname; }
@@ -53,10 +57,13 @@ public class KANTVLLMModel {
     }
 
     public String getMMProjName() { return mmproj_name; }
+    public String getMMProjUrl() { return mmproj_url; }
+    public void setMmprojUrl(String mmprojUrl) { this.mmproj_url = mmprojUrl; }
 
     public String getUrl() {
         return url;
     }
+    public void setUrl(String modelUrl) { this.url = modelUrl;}
 
     public int getIndex() {
         return index;
@@ -67,4 +74,6 @@ public class KANTVLLMModel {
     public void setQuality(String quality) {
         this.quality = quality;
     }
+
+
 }

--- a/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVLLMModelMgr.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVLLMModelMgr.java
@@ -1,0 +1,123 @@
+ /*
+  * Copyright (c) 2024- KanTV Authors
+  *
+  * Permission is hereby granted, free of charge, to any person obtaining a copy
+  * of this software and associated documentation files (the "Software"), to
+  * deal in the Software without restriction, including without limitation the
+  * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+  * sell copies of the Software, and to permit persons to whom the Software is
+  * furnished to do so, subject to the following conditions:
+  *
+  * The above copyright notice and this permission notice shall be included in
+  * all copies or substantial portions of the Software.
+  *
+  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+  * IN THE SOFTWARE.
+  */
+package kantvai.media.player;
+
+public class KANTVLLMModelMgr {
+    private static final String TAG = KANTVLLMModelMgr.class.getSimpleName();
+
+    //https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/tree/main
+    //default LLM model
+    private String defaultModelName = "gemma-3-4b-it-Q8_0.gguf"; //4.1 GiB
+    private int defaultModelIndex = 4; //index of selected LLM model, default index is 4 (gemma-3-4b)
+    private final int LLM_MODEL_MAXCOUNTS    = 8;
+    private KANTVLLMModel[] LLMModels        = new KANTVLLMModel[LLM_MODEL_MAXCOUNTS];
+    private String[]        arrayModelName   = new String[LLM_MODEL_MAXCOUNTS + 1]; //contains all LLM models + ggml-tiny.en-q8_0.bin
+
+    private static KANTVLLMModelMgr instance = null;
+    private static volatile boolean isInitModels = false;
+
+    private KANTVLLMModelMgr() {
+        KANTVLog.g(TAG, "private constructor");
+    }
+
+    public static KANTVLLMModelMgr getInstance() {
+        if (!isInitModels) {
+            instance = new KANTVLLMModelMgr();
+            instance.initLLMModels();
+            isInitModels = true;
+        } else {
+            KANTVLog.d(TAG, "KANTVLLMModelMgr already inited");
+        }
+        return instance;
+    }
+
+    private void initLLMModels() {
+        KANTVLog.g(TAG, "initLLMModels");
+        //how to convert safetensors to GGUF and quantize LLM model:https://www.kantvai.com/posts/Convert-safetensors-to-gguf.html
+        LLMModels[0] = new KANTVLLMModel(0, "Qwen1.5-1.8B", "qwen1_5-1_8b-chat-q4_0.gguf", "https://huggingface.co/Qwen/Qwen1.5-1.8B-Chat-GGUF/blob/main/qwen1_5-1_8b-chat-q4_0.gguf");
+        LLMModels[1] = new KANTVLLMModel(1, "Qwen2.5-3B", "qwen2.5-3b-instruct-q4_0.gguf", "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF/tree/main");
+        LLMModels[2] = new KANTVLLMModel(2, "Qwen3-4B","Qwen3-4B-Q8_0.gguf", "https://huggingface.co/Qwen/Qwen3-4B/tree/main");
+        LLMModels[3] = new KANTVLLMModel(3, "Qwen3-8B", "Qwen3-8B-Q8_0.gguf", "https://huggingface.co/Qwen/Qwen3-8B");
+        LLMModels[4] = new KANTVLLMModel(4, "Gemma3-4B", "gemma-3-4b-it-Q8_0.gguf","mmproj-gemma3-4b-f16.gguf", "https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/tree/main", "good");
+        LLMModels[5] = new KANTVLLMModel(5, "Gemma3-12B", "gemma-3-12b-it-Q4_K_M.gguf", "mmproj-gemma3-12b-f16.gguf", "https://huggingface.co/ggml-org/gemma-3-12b-it-GGUF/tree/main", "good");
+        LLMModels[6] = new KANTVLLMModel(6, "DS-R1-Distill-Qwen-1.5B", "DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf", "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B");
+        LLMModels[7] = new KANTVLLMModel(7, "DS-R1-Distill-Qwen-7B", "DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf", "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B/tree/main");
+
+
+        arrayModelName[0] = "ggml-tiny.en-q8_0.bin"; //the built-in and default ASR model, size is 42 MiB
+        for (int i = 1; i <= LLM_MODEL_MAXCOUNTS; i++) {
+            arrayModelName[i] = LLMModels[i - 1].getNickname();
+        }
+        LLMModels[0].setQuality("not bad and fast");
+        LLMModels[1].setQuality("good");
+        LLMModels[2].setQuality("not bad");
+        LLMModels[3].setQuality("slow but impressive");//can understand word counts should be less then 100, but many repeated sentences
+        LLMModels[4].setQuality("perfect"); //inference speed is fast and the answer is concise and accurate is exactly what I
+        LLMModels[5].setQuality("slow and good");
+        LLMModels[6].setQuality("bad"); //inference speed is fast but the answer is wrong
+        LLMModels[7].setQuality("not bad"); //the answer is not concise
+
+        //make LLM downloader happy
+        LLMModels[4].setUrl("https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q8_0.gguf?download=true"); //4.13 GiB
+        LLMModels[4].setMmprojUrl("https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/resolve/main/mmproj-model-f16.gguf?download=true");//851 MiB
+    }
+
+    public String[] getArrayModelName() {
+        return arrayModelName;
+    }
+
+    public int getLLMModelMaxCounts() {
+        return LLM_MODEL_MAXCOUNTS;
+    }
+
+    public String getName(int index) {
+        return LLMModels[index].getName();
+    }
+
+    public String getNickname(int index) {
+        return LLMModels[index].getNickname();
+    }
+
+    public String getModelUrl(int index) {
+        return LLMModels[index].getUrl();
+    }
+
+    public String getMMProjName(int index) {
+        return LLMModels[index].getMMProjName();
+    }
+
+    public String getMMProjUrl(int index) {
+        return LLMModels[index].getMMProjUrl();
+    }
+
+    public String getDefaultModelName() {
+        return LLMModels[defaultModelIndex].getName();
+    }
+
+    public String getDefaultModelUrl() {
+        return LLMModels[defaultModelIndex].getUrl();
+    }
+
+    public int getDefaultModelIndex() {
+        return defaultModelIndex;
+    }
+}

--- a/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVUtils.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVUtils.java
@@ -4101,8 +4101,8 @@
      }
 
 
-     public static String getGGMLModeString(int ggmlModeType) {
-         switch (ggmlModeType) {
+     public static String getASRModelString(int asrModelType) {
+         switch (asrModelType) {
              case 0:
                  return "tiny";
              case 1:
@@ -4142,12 +4142,12 @@
      }
 
 
-     public int getASRMode() {
+     public static int getASRMode() {
          return mASRMode;
      }
 
 
-     public String getASRModeString( int asrMode) {
+     public static String getASRModeString( int asrMode) {
          switch (asrMode) {
              case ASR_MODE_NORMAL:
                  return "ASR_MODE_NORMAL";

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/app/IApplication.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/app/IApplication.java
@@ -387,9 +387,9 @@ public class IApplication extends Application {
 
         int asrMode = mSettings.getASRMode();  //default is normal transcription
         int asrThreadCounts = mSettings.getASRThreadCounts(); //default is 4
-        KANTVLog.j(TAG, "GGML mode: " + mSettings.getGGMLMode());
-        KANTVLog.j(TAG, "GGML mode name: " + KANTVUtils.getGGMLModeString(mSettings.getGGMLMode()));
-        String modelPath = KANTVUtils.getDataPath() + "ggml-" + KANTVUtils.getGGMLModeString(mSettings.getGGMLMode()) + ".bin";
+        KANTVLog.j(TAG, "ASR model: " + mSettings.getASRModel());
+        KANTVLog.j(TAG, "ASR model name: " + KANTVUtils.getASRModelString(mSettings.getASRModel()));
+        String modelPath = KANTVUtils.getDataPath() + "ggml-" + KANTVUtils.getASRModelString(mSettings.getASRModel()) + ".bin";
         KANTVLog.j(TAG, "modelPath:" + modelPath);
 
         //preload GGML model and initialize asr_subsystem as early as possible for purpose of ASR real-time performance
@@ -398,6 +398,7 @@ public class IApplication extends Application {
             KANTVLibraryLoader.load("ggml-jni");
             KANTVLog.d(TAG, "cpu core counts:" + ggmljava.get_cpu_core_counts());
             KANTVLog.j(TAG, "asr mode: " + mSettings.getASRMode());
+            KANTVLog.g(TAG, "asr mode string: " + KANTVUtils.getASRModeString(mSettings.getASRMode()));
             if ((KANTVUtils.ASR_MODE_NORMAL == mSettings.getASRMode()) || (KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD == mSettings.getASRMode())) {
                 result = ggmljava.asr_init(modelPath, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
             } else {

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/player/ffplayer/FFPlayerView.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/player/ffplayer/FFPlayerView.java
@@ -1551,7 +1551,7 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
         //String ggmlModelFileName = "ggml-tiny-q5_1.bin";      // 31M
         //String ggmlModelFileName = "ggml-tiny.en-q5_1.bin";   // 31M
         String ggmlModelFileName = "ggml-tiny.en-q8_0.bin";     // 42M, very good, about 500-700 ms
-        String userChooseModelName = KANTVUtils.getGGMLModeString(mSettings.getGGMLMode());
+        String userChooseModelName = KANTVUtils.getASRModelString(mSettings.getASRModel());
         String userChooseModelFileName = "ggml-" + userChooseModelName + ".bin";
         KANTVLog.j(TAG, "ggml model name of user's choose:" + userChooseModelFileName);
 
@@ -1580,6 +1580,7 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
 
         if (KANTVUtils.getASRSubsystemInit()) {
             int result = 0;
+            KANTVLog.j(TAG, "asr mode string: " + KANTVUtils.getASRModeString(mSettings.getASRMode()));
             if ((KANTVUtils.ASR_MODE_NORMAL == mSettings.getASRMode()) || (KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD == mSettings.getASRMode())) {
                 result = ggmljava.asr_reset(KANTVUtils.getDataPath() + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
             } else {

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/LLMResearchFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/LLMResearchFragment.java
@@ -66,6 +66,7 @@
  import kantvai.media.player.KANTVEventType;
  import kantvai.media.player.KANTVException;
  import kantvai.media.player.KANTVLLMModel;
+ import kantvai.media.player.KANTVLLMModelMgr;
  import kantvai.media.player.KANTVLibraryLoader;
  import kantvai.media.player.KANTVLog;
  import kantvai.media.player.KANTVMgr;
@@ -113,11 +114,8 @@
 
      private AtomicBoolean isBenchmarking = new AtomicBoolean(false);
 
-
-     //https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/tree/main
-     //default LLM model
-     private String LLMModelFileName = "gemma-3-4b-it-Q8_0.gguf"; //4.1 GiB
-     private String LLMModelURL = "https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/tree/main";
+     private String LLMModelFileName;
+     private String LLMModelURL;
      String selectModelFilePath = "";
      private String strUserInput = "introduce the movie Once Upon a Time in America briefly, less then 100 words\n";
      private Context mContext;
@@ -125,23 +123,11 @@
      private Settings mSettings;
      private KANTVMgr mKANTVMgr = null;
      private LLMResearchFragment.MyEventListener mEventListener = new LLMResearchFragment.MyEventListener();
+     private KANTVLLMModelMgr LLMModelMgr = KANTVLLMModelMgr.getInstance();
 
-     private final int LLM_MODEL_MAXCOUNTS  = 8;
-     private KANTVLLMModel[] LLMModels      = new KANTVLLMModel[LLM_MODEL_MAXCOUNTS];
-     private int selectModelIndex           = 4; //gemma-3-4b
-     //not practically used currently, keep this function for further usage
      private void initLLMModels() {
-         //how to convert safetensors to GGUF and quantize LLM model:https://www.kantvai.com/posts/Convert-safetensors-to-gguf.html
-         LLMModels[0] = new KANTVLLMModel(0, "Qwen1.5-1.8B", "qwen1_5-1_8b-chat-q4_0.gguf", "https://huggingface.co/Qwen/Qwen1.5-1.8B-Chat-GGUF/blob/main/qwen1_5-1_8b-chat-q4_0.gguf");
-         LLMModels[1] = new KANTVLLMModel(1, "Qwen2.5-3B", "qwen2.5-3b-instruct-q4_0.gguf", "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF/tree/main");
-         LLMModels[2] = new KANTVLLMModel(2, "Qwen3-4B","Qwen3-4B-Q8_0.gguf", "https://huggingface.co/Qwen/Qwen3-4B/tree/main");
-         LLMModels[3] = new KANTVLLMModel(3, "Qwen3-8B", "Qwen3-8B-Q8_0.gguf", "https://huggingface.co/Qwen/Qwen3-8B");
-         LLMModels[4] = new KANTVLLMModel(4, "Gemma3-4B", "gemma-3-4b-it-Q8_0.gguf","mmproj-gemma3-4b-f16.gguf", "https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/tree/main", "good");
-         LLMModels[5] = new KANTVLLMModel(5, "Gemma3-12B", "gemma-3-12b-it-Q4_K_M.gguf", "mmproj-gemma3-12b-f16.gguf", "https://huggingface.co/ggml-org/gemma-3-12b-it-GGUF/tree/main", "good");
-         LLMModels[6] = new KANTVLLMModel(6, "DS-R1-Distill-Qwen-1.5B", "DeepSeek-R1-Distill-Qwen-1.5B-Q8_0.gguf", "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B");
-         LLMModels[7] = new KANTVLLMModel(7, "DS-R1-Distill-Qwen-7B", "DeepSeek-R1-Distill-Qwen-7B-Q8_0.gguf", "https://huggingface.co/deepseek-ai/DeepSeek-R1-Distill-Qwen-7B/tree/main");
-         LLMModelFileName = LLMModels[selectModelIndex].getName();
-         LLMModelURL      = LLMModels[selectModelIndex].getUrl();
+         LLMModelFileName = LLMModelMgr.getDefaultModelName();
+         LLMModelURL = LLMModelMgr.getDefaultModelUrl();
      }
 
      public static LLMResearchFragment newInstance() {

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/PersonalFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/PersonalFragment.java
@@ -39,6 +39,7 @@
 
  import com.blankj.utilcode.util.ConvertUtils;
  import com.kantvai.kantvplayer.ui.activities.personal.CustomEPGListActivity;
+ import com.kantvai.kantvplayer.ui.fragment.settings.LLMSettingFragment;
  import com.kantvai.kantvplayer.ui.fragment.settings.SystemSettingFragment;
  import com.kantvai.kantvplayer.R;
  import com.kantvai.kantvplayer.base.BaseMvpFragment;
@@ -160,8 +161,8 @@
 
      @OnClick({
              R.id.system_setting_ll, R.id.play_setting_ll, R.id.record_setting_ll,
-             R.id.local_history_ll, R.id.peformance_benchmark_ll, R.id.asr_setting_ll,
-             R.id.custom_playlist_ll, R.id.exit_app_ll
+             R.id.local_history_ll, R.id.llm_setting_ll, R.id.asr_setting_ll,
+             R.id.peformance_benchmark_ll, R.id.custom_playlist_ll, R.id.exit_app_ll
      })
      public void onViewClicked(View view) {
          switch (view.getId()) {
@@ -177,24 +178,30 @@
                  launchActivity(ShellActivity.class, player);
                  break;
 
+             case R.id.local_history_ll:
+                 launchActivity(LocalPlayHistoryActivity.class);
+                 break;
+
              case R.id.record_setting_ll:
                  Bundle download = new Bundle();
                  download.putString("fragment", RecordSettingFragment.class.getName());
                  launchActivity(ShellActivity.class, download);
                  break;
 
+             case R.id.llm_setting_ll:
+                 Bundle llm = new Bundle();
+                 llm.putString("fragment", LLMSettingFragment.class.getName());
+                 launchActivity(ShellActivity.class, llm);
+                 break;
+
              case R.id.asr_setting_ll:
-                 Bundle voice = new Bundle();
-                 voice.putString("fragment", ASRSettingFragment.class.getName());
-                 launchActivity(ShellActivity.class, voice);
+                 Bundle asr = new Bundle();
+                 asr.putString("fragment", ASRSettingFragment.class.getName());
+                 launchActivity(ShellActivity.class, asr);
                  break;
 
              case R.id.peformance_benchmark_ll:
                  launchActivity(BenchmarkActivity.class);
-                 break;
-
-             case R.id.local_history_ll:
-                 launchActivity(LocalPlayHistoryActivity.class);
                  break;
 
              case R.id.custom_playlist_ll:

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/settings/LLMSettingFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/settings/LLMSettingFragment.java
@@ -44,12 +44,13 @@
 
  import java.io.File;
 
+ import kantvai.media.player.KANTVLLMModelMgr;
  import kantvai.media.player.KANTVLog;
  import kantvai.media.player.KANTVUtils;
 
 
- public class ASRSettingFragment extends BaseSettingsFragment {
-     private static final String TAG = ASRSettingFragment.class.getName();
+ public class LLMSettingFragment extends BaseSettingsFragment {
+     private static final String TAG = LLMSettingFragment.class.getName();
      private static ShellActivity mActivity;
      private Context mContext;
      private Context mAppContext;
@@ -59,7 +60,7 @@
 
      @Override
      public String getTitle() {
-         return mActivity.getBaseContext().getString(R.string.asr_settings);
+         return mActivity.getBaseContext().getString(R.string.llm_settings);
      }
 
      @Override
@@ -76,30 +77,20 @@
          mContext = mActivity.getBaseContext();
          mSettings.updateUILang(mActivity);
 
-         addPreferencesFromResource(R.xml.settings_asr);
+         addPreferencesFromResource(R.xml.settings_llm);
          mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(mAppContext);
 
-         KANTVLog.j(TAG, "dev mode:" + mSettings.getDevMode());
-         //NPU or dedicated hardware AI engine in Android device not supported currently
-         if (!mSettings.getDevMode()) {
-             if (findPreference("pref.voiceapi") != null) {
-                 findPreference("pref.voiceapi").setEnabled(true);
+         KANTVLog.g(TAG, "getHexagonEnabled:" + mSettings.getHexagonEnabled());
+         if (!mSettings.getHexagonEnabled()) {
+             if (findPreference("pref.backend") != null) {
+                 findPreference("pref.backend").setEnabled(false);
              }
          }
-
-
      }
 
      @Override
      public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
          super.onViewCreated(view, savedInstanceState);
-
-         if (findPreference("pref.voiceapi") != null) {
-             findPreference("pref.voiceapi").setOnPreferenceClickListener(preference -> {
-                 KANTVUtils.showMsgBox(mActivity, "This feature not implemented currently");
-                 return false;
-             });
-         }
      }
 
 
@@ -124,19 +115,19 @@
      private SharedPreferences.OnSharedPreferenceChangeListener mSharedPreferenceChangeListener = new SharedPreferences.OnSharedPreferenceChangeListener() {
          @Override
          public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
-             KANTVLog.j(TAG, "key : " + key);
+             KANTVLog.g(TAG, "key : " + key);
              if (
-                 (key.contains("pref.asrmode"))
-                 || (key.contains("pref.asrthreadcounts"))
-                 || (key.contains("pref.asrmodel"))
+                 (key.contains("pref.backend"))
+                 || (key.contains("pref.llmthreadcounts"))
+                 || (key.contains("pref.llmmodel"))
              ) {
-                 KANTVLog.j(TAG, "asrmode: " + mSettings.getASRMode());
-                 KANTVLog.j(TAG, "asrthreadCounts " + mSettings.getASRThreadCounts());
-                 KANTVLog.j(TAG, "ASR model: " + mSettings.getASRModel());
-                 KANTVLog.j(TAG, "ASR model name: " + KANTVUtils.getASRModelString(mSettings.getASRModel()));
-                 String modelPath = KANTVUtils.getDataPath() + "ggml-" + KANTVUtils.getASRModelString(mSettings.getASRModel()) + ".bin";
-                 KANTVLog.j(TAG, "modelPath:" + modelPath);
-                 KANTVUtils.setASRConfig("whispercpp", modelPath, mSettings.getASRThreadCounts(), mSettings.getASRMode());
+                 KANTVLog.g(TAG, "LLM backend: " + mSettings.getLLMbackend());
+                 KANTVLog.g(TAG, "LLM threadCounts " + mSettings.getLLMThreadCounts());
+                 KANTVLog.g(TAG, "LLM model: " + mSettings.getLLMModel());
+                 KANTVLog.g(TAG, "LLM model name: " + KANTVLLMModelMgr.getInstance().getName(mSettings.getLLMModel()));
+                 String modelPath = KANTVUtils.getSDCardDataPath() + KANTVLLMModelMgr.getInstance().getName(mSettings.getLLMModel());
+                 KANTVLog.g(TAG, "modelPath:" + modelPath);
+                 //KANTVUtils.setASRConfig("whispercpp", modelPath, mSettings.getASRThreadCounts(), mSettings.getASRMode());
              }
          }
      };
@@ -145,42 +136,47 @@
      @Override
      public boolean onPreferenceTreeClick(Preference preference) {
          String key = preference.getKey();
-         KANTVLog.j(TAG, "key : " + key);
+         KANTVLog.g(TAG, "key : " + key);
          if (preference instanceof CheckBoxPreference) {
              KANTVLog.d(TAG, "preference : " + preference.getKey() + ", status:" + mSharedPreferences.getBoolean(key, false));
          }
 
-
-         //focus on GGML's model
-         if (key.contains("pref.downloadASRmodel")) {
-             KANTVLog.j(TAG, "download ASR model");
+         if (key.contains("pref.downloadLLMmodel")) {
+             KANTVLog.j(TAG, "download LLM model");
              WindowManager.LayoutParams attributes = mActivity.getWindow().getAttributes();
              attributes.screenBrightness = 1.0f;
              mActivity.getWindow().setAttributes(attributes);
              mActivity.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
 
-             String asrAudioFileName = KANTVUtils.getDataPath() + "jfk.wav";
-             //String asrModelFileName = KANTVUtils.getDataPath(mContext) + "ggml-tiny.en-q8_0.bin";
-             String userChooseModelName = KANTVUtils.getASRModelString(mSettings.getASRModel());
-             KANTVLog.g(TAG, "ASR model name of user choose:" + userChooseModelName);
-             String userChooseModelFileName = "ggml-" + userChooseModelName + ".bin";
-             File asrAudioFile = new File(asrAudioFileName);
-             File asrModelFile = new File(KANTVUtils.getDataPath() + userChooseModelFileName);
-             KANTVLog.g(TAG, "asrAudioFile:" + asrAudioFile.getAbsolutePath());
-             KANTVLog.g(TAG, "asrModeFile:" + asrModelFile.getAbsolutePath());
-             if (
-                     (asrAudioFile == null) || (!asrAudioFile.exists())
-                             || (asrModelFile == null) || (!asrModelFile.exists())
-             ) {
+             String userChooseModelName = KANTVLLMModelMgr.getInstance().getName(mSettings.getLLMModel());
+             KANTVLog.g(TAG, "LLM model name of user choose:" + userChooseModelName);
+             File llmModelFile = new File(KANTVUtils.getSDCardDataPath() + userChooseModelName);
+             KANTVLog.g(TAG, "llmModeFile:" + llmModelFile.getAbsolutePath());
+
+             //TODO:add support download other LLM models
+             if (mSettings.getLLMModel() != KANTVLLMModelMgr.getInstance().getDefaultModelIndex()) {
+                 KANTVUtils.showMsgBox(mActivity, "currently only support download Gemma3-4B:model size 4.13 GiB, mmproj size 851 MiB");
+                 return true;
+             }
+             KANTVLog.g(TAG, "model url:" +  KANTVLLMModelMgr.getInstance().getModelUrl(mSettings.getLLMModel()));
+             KANTVLog.g(TAG, "mmproj url:"+  KANTVLLMModelMgr.getInstance().getMMProjUrl(mSettings.getLLMModel()));
+
+             if (llmModelFile.exists()) {
+                 KANTVLog.g(TAG, "LLM model file already exist: " + KANTVUtils.getDataPath() + userChooseModelName);
+                 //Toast.makeText(mContext, "LLM model file already exist: " + KANTVUtils.getDataPath() + userChooseModelFileName, Toast.LENGTH_SHORT).show();
+                 KANTVUtils.showMsgBox(mActivity, "LLM model file already exist: " + KANTVUtils.getDataPath() + userChooseModelName);
+                 return true;
+             }
+
+             if ((llmModelFile == null) || (!llmModelFile.exists())) {
                  DownloadModel manager = new DownloadModel(mActivity);
-                 manager.setTitle("begin download ASR model and sample");
-                 manager.setModelName("ASR");
-                 manager.setModelName("GGML", "jfk.wav", userChooseModelFileName);
+                 manager.setTitle("begin download LLM model");
+                 manager.setModelName("LLM");
+                 manager.setLLMModelName("GGML",  userChooseModelName,
+                         KANTVLLMModelMgr.getInstance().getMMProjName(mSettings.getLLMModel()),
+                         KANTVLLMModelMgr.getInstance().getModelUrl(mSettings.getLLMModel()),
+                         KANTVLLMModelMgr.getInstance().getMMProjUrl(mSettings.getLLMModel()));
                  manager.showUpdateDialog();
-             } else {
-                 KANTVLog.j(TAG, "ASR model file already exist: " + KANTVUtils.getDataPath() + userChooseModelFileName);
-                 //Toast.makeText(mContext, "ASR model file already exist: " + KANTVUtils.getDataPath() + userChooseModelFileName, Toast.LENGTH_SHORT).show();
-                 KANTVUtils.showMsgBox(mActivity, "ASR model file already exist: " + KANTVUtils.getDataPath() + userChooseModelFileName);
              }
          }
 

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/settings/LLMSettingFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/settings/LLMSettingFragment.java
@@ -1,5 +1,4 @@
  /*
-  * Copyright (c) Project KanTV. 2021-2023
   * Copyright (c) 2024- KanTV Authors
   *
   * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/utils/Settings.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/utils/Settings.java
@@ -88,8 +88,8 @@ public class Settings {
     }
 
 
-    public int getGGMLMode() {
-        String key = mAppContext.getString(R.string.pref_key_ggmlmodel);
+    public int getASRModel() {
+        String key = mAppContext.getString(R.string.pref_key_asrmodel);
         String value = mSharedPreferences.getString(key, "3"); //tiny.en-q8_0
         try {
             return Integer.valueOf(value).intValue();
@@ -448,4 +448,42 @@ public class Settings {
         String key = "auto_load_local_subtitle";
         return mSharedPreferences.getBoolean(key, true);
     }
+
+    public int getLLMbackend() {
+        String key = mAppContext.getString(R.string.pref_key_backend);
+        String value = mSharedPreferences.getString(key, "1"); //actual backend is 1 + 3 = 4
+        try {
+            return Integer.valueOf(value).intValue() + 3; //skip QNN-CPU,QNN-GPU,QNN-NPU
+        } catch (NumberFormatException e) {
+            KANTVLog.j(TAG, "exception occurred");
+            return 4;
+        }
+    }
+
+    public int getLLMThreadCounts() {
+        String key = mAppContext.getString(R.string.pref_key_llmthreadcounts);
+        String value = mSharedPreferences.getString(key, "3"); // actual thread counts is 3 + 1 = 4
+        try {
+            return Integer.valueOf(value).intValue() + 1;
+        } catch (NumberFormatException e) {
+            KANTVLog.j(TAG, "exception occurred");
+            return 4;
+        }
+    }
+
+    public int getLLMModel() {
+        String key = mAppContext.getString(R.string.pref_key_llmmodel);
+        String value = mSharedPreferences.getString(key, "4"); //Gemma3-4B
+        try {
+            return Integer.valueOf(value).intValue();
+        } catch (NumberFormatException e) {
+            KANTVLog.j(TAG, "exception occurred");
+            return 4;
+        }
+    }
+
+    public boolean getHexagonEnabled() {
+        return true;
+    }
+
 }

--- a/android/kantvplayer/src/main/res/layout/fragment_personal.xml
+++ b/android/kantvplayer/src/main/res/layout/fragment_personal.xml
@@ -67,6 +67,8 @@
                     android:textSize="12sp" />
             </LinearLayout>
 
+
+
             <LinearLayout
                 android:id="@+id/record_setting_ll"
                 android:layout_width="0dp"
@@ -89,7 +91,7 @@
                     android:layout_gravity="center_horizontal"
                     android:layout_marginTop="5dp"
                     android:text="@string/record_settings"
-                    android:textColor="@color/text_gray"
+                    android:textColor="@color/text_black"
                     android:textSize="12sp" />
             </LinearLayout>
 
@@ -132,14 +134,11 @@
             </LinearLayout>
 
             <LinearLayout
-                android:id="@+id/peformance_benchmark_ll"
+                android:id="@+id/llm_setting_ll"
                 android:layout_width="0dp"
                 android:layout_height="match_parent"
-                android:layout_marginStart="2dp"
-                android:layout_marginEnd="1dp"
                 android:layout_weight="1"
-                android:background="@color/item_bg_color"
-                android:foreground="?android:attr/selectableItemBackground"
+                android:background="?android:attr/selectableItemBackground"
                 android:gravity="center"
                 android:orientation="vertical">
 
@@ -147,15 +146,15 @@
                     android:layout_width="30dp"
                     android:layout_height="30dp"
                     android:layout_gravity="center_horizontal"
-                    android:src="@mipmap/ic_personal_benchmark" />
+                    android:src="@mipmap/ic_personal_app_setting" />
 
                 <TextView
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
                     android:layout_gravity="center_horizontal"
-                    android:layout_marginTop="8dp"
-                    android:text="@string/performance_bechmark"
-                    android:textColor="@color/text_black"
+                    android:layout_marginTop="5dp"
+                    android:text="@string/llm_settings"
+                    android:textColor="@color/text_gray"
                     android:textSize="12sp" />
             </LinearLayout>
 
@@ -196,6 +195,34 @@
             android:layout_height="80dp"
             android:layout_marginTop="2dp"
             android:weightSum="3">
+
+            <LinearLayout
+                android:id="@+id/peformance_benchmark_ll"
+                android:layout_width="0dp"
+                android:layout_height="match_parent"
+                android:layout_marginStart="2dp"
+                android:layout_marginEnd="1dp"
+                android:layout_weight="1"
+                android:background="@color/item_bg_color"
+                android:foreground="?android:attr/selectableItemBackground"
+                android:gravity="center"
+                android:orientation="vertical">
+
+                <ImageView
+                    android:layout_width="30dp"
+                    android:layout_height="30dp"
+                    android:layout_gravity="center_horizontal"
+                    android:src="@mipmap/ic_personal_benchmark" />
+
+                <TextView
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:layout_gravity="center_horizontal"
+                    android:layout_marginTop="8dp"
+                    android:text="@string/performance_bechmark"
+                    android:textColor="@color/text_black"
+                    android:textSize="12sp" />
+            </LinearLayout>
 
             <LinearLayout
                 android:id="@+id/custom_playlist_ll"

--- a/android/kantvplayer/src/main/res/values-en/strings.xml
+++ b/android/kantvplayer/src/main/res/values-en/strings.xml
@@ -194,6 +194,8 @@
     <string name="play_history">Play History</string>
     <string name="performance_bechmark">Benchmark</string>
     <string name="asr_settings">ASR Setting</string>
+    <string name="llm_settings">LLM Setting</string>
+    <string name="hexagon_settings">Hexagon Setting</string>
     <string name="video_scan">Video Scan</string>
     <string name="general_question">Help</string>
     <string name="skin_nighttime">Night Mode</string>

--- a/android/kantvplayer/src/main/res/values-en/strings_pref.xml
+++ b/android/kantvplayer/src/main/res/values-en/strings_pref.xml
@@ -127,9 +127,10 @@
         <item>7</item>
     </string-array>
 
-    <string name="pref_key_ggmlmodel">pref.ggmlmodel</string>
-    <string name="pref_title_ggmlmodel">Choose GGML model</string>
-    <string-array name="pref_entries_ggmlmodel">
+    <string name="pref_title_asr">ASR</string>
+    <string name="pref_key_asrmodel">pref.asrmodel</string>
+    <string name="pref_title_asrmodel">Choose ASR model</string>
+    <string-array name="pref_entries_asrmodel">
         <item>tiny</item>
         <item>tiny.en</item>
         <item>tiny.en-q5_1</item>
@@ -147,7 +148,7 @@
         <item>medium.en-q5_0</item>
         <item>large</item>
     </string-array>
-    <string-array name="pref_entry_values_ggmlmodel">
+    <string-array name="pref_entry_values_asrmodel">
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -165,7 +166,7 @@
         <item>14</item>
         <item>15</item>
     </string-array>
-    <string-array name="pref_entry_summaries_ggmlmodel">
+    <string-array name="pref_entry_summaries_asrmodel">
             <item>tiny</item>
             <item>tiny.en</item>
             <item>tiny.en-q5_1</item>
@@ -415,15 +416,9 @@
     <string name="pref_title_exitapp">Exit app </string>
     <string name="pref_summary_exitapp">click to exit app</string>
 
-    <string name="pref_title_ASRmodel"></string>
     <string name="pref_key_downloadASRmodel">pref.downloadASRmodel</string>
     <string name="pref_title_downloadASRmodel">Download ASR model</string>
     <string name="pref_summary_downloadASRmodel">Download ASR model</string>
-
-    <string name="pref_title_GGMLmodel"></string>
-    <string name="pref_key_downloadGGMLmodel">pref.downloadGGMLmodel</string>
-    <string name="pref_title_downloadGGMLmodel">Download GGML model</string>
-    <string name="pref_summary_downloadGGMLmodel">Download GGML model</string>
 
     <string name="pref_title_TTSmodel"></string>
     <string name="pref_key_downloadTTSmodel">pref.downloadTTSmodel</string>
@@ -515,6 +510,77 @@
     <string name="pref_title_record_thresholddisksize">threshold disk size</string>
     <string name="pref_summary_record_thresholddisksize" translatable="false">click to setting threshold disk size(Mbytes)</string>
 
+    <string name="pref_key_backend">pref.backend</string>
+    <string name="pref_title_backend">Choose Backend</string>
+    <string-array name="pref_entries_backend">
+        <item>Hexagon cDSP</item>
+        <item>Default ggml</item>
+    </string-array>
+    <string-array name="pref_entry_values_backend">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_entry_summaries_backend">
+        <item>offload GGML OP to cDSP directly</item>
+        <item>default ggml backend</item>
+    </string-array>
+
+    <string name="pref_key_llmthreadcounts">pref.llmthreadcounts</string>
+    <string name="pref_title_llmthreadcounts">Choose LLM thread counts</string>
+    <string-array name="pref_entries_llmthreadcounts">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+    </string-array>
+    <string-array name="pref_entry_values_llmthreadcounts">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+    </string-array>
+
+    <string name="pref_title_llm">LLM</string>
+    <string name="pref_key_llmmodel">pref.llmmodel</string>
+    <string name="pref_title_llmmodel">Choose LLM model</string>
+    <string-array name="pref_entries_llmmodel">
+        <item>Qwen1.5-1.8B</item>
+        <item>Qwen2.5-3B</item>
+        <item>Qwen3-4B</item>
+        <item>Qwen3-8B</item>
+        <item>Gemma3-4B</item>
+        <item>Gemma3-12B</item>
+    </string-array>
+    <string-array name="pref_entry_values_llmmodel">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+    </string-array>
+    <string-array name="pref_entry_summaries_llmmodel">
+        <item>Qwen1.5-1.8B</item>
+        <item>Qwen2.5-3B</item>
+        <item>Qwen3-4B</item>
+        <item>Qwen3-8B</item>
+        <item>Gemma3-4B</item>
+        <item>Gemma3-12B</item>
+    </string-array>
+
+    <string name="pref_title_LLMmodel"></string>
+    <string name="pref_key_downloadLLMmodel">pref.downloadLLMmodel</string>
+    <string name="pref_title_downloadLLMmodel">Download LLM model</string>
+    <string name="pref_summary_downloadLLMmodel">Download LLM model</string>
 
     <string name="pref_key_last_directory"></string>
 

--- a/android/kantvplayer/src/main/res/values-zh/strings.xml
+++ b/android/kantvplayer/src/main/res/values-zh/strings.xml
@@ -194,6 +194,8 @@
     <string name="play_history">Play History</string>
     <string name="performance_bechmark">Benchmark</string>
     <string name="asr_settings">ASR Setting</string>
+    <string name="llm_settings">LLM Setting</string>
+    <string name="hexagon_settings">Hexagon Setting</string>
     <string name="video_scan">Video Scan</string>
     <string name="general_question">Help</string>
     <string name="skin_nighttime">Night Mode</string>

--- a/android/kantvplayer/src/main/res/values-zh/strings_pref.xml
+++ b/android/kantvplayer/src/main/res/values-zh/strings_pref.xml
@@ -127,9 +127,10 @@
         <item>7</item>
     </string-array>
 
-    <string name="pref_key_ggmlmodel">pref.ggmlmodel</string>
-    <string name="pref_title_ggmlmodel">Choose GGML model</string>
-    <string-array name="pref_entries_ggmlmodel">
+    <string name="pref_title_asr">ASR</string>
+    <string name="pref_key_asrmodel">pref.asrmodel</string>
+    <string name="pref_title_asrmodel">Choose ASR model</string>
+    <string-array name="pref_entries_asrmodel">
         <item>tiny</item>
         <item>tiny.en</item>
         <item>tiny.en-q5_1</item>
@@ -147,7 +148,7 @@
         <item>medium.en-q5_0</item>
         <item>large</item>
     </string-array>
-    <string-array name="pref_entry_values_ggmlmodel">
+    <string-array name="pref_entry_values_asrmodel">
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -165,7 +166,7 @@
         <item>14</item>
         <item>15</item>
     </string-array>
-    <string-array name="pref_entry_summaries_ggmlmodel">
+    <string-array name="pref_entry_summaries_asrmodel">
             <item>tiny</item>
             <item>tiny.en</item>
             <item>tiny.en-q5_1</item>
@@ -382,7 +383,6 @@
     </string-array>
 
 
-
     <string name="pref_title_about">About</string>
     <string name="pref_key_version">pref.version</string>
     <string name="pref_title_version">Current Version</string>
@@ -415,15 +415,9 @@
     <string name="pref_title_exitapp">Exit app </string>
     <string name="pref_summary_exitapp">click to exit app</string>
 
-    <string name="pref_title_ASRmodel"></string>
     <string name="pref_key_downloadASRmodel">pref.downloadASRmodel</string>
     <string name="pref_title_downloadASRmodel">Download ASR model</string>
     <string name="pref_summary_downloadASRmodel">Download ASR model</string>
-
-    <string name="pref_title_GGMLmodel"></string>
-    <string name="pref_key_downloadGGMLmodel">pref.downloadGGMLmodel</string>
-    <string name="pref_title_downloadGGMLmodel">Download GGML model</string>
-    <string name="pref_summary_downloadGGMLmodel">Download GGML model</string>
 
     <string name="pref_title_TTSmodel"></string>
     <string name="pref_key_downloadTTSmodel">pref.downloadTTSmodel</string>
@@ -515,6 +509,77 @@
     <string name="pref_title_record_thresholddisksize">threshold disk size</string>
     <string name="pref_summary_record_thresholddisksize" translatable="false">click to setting threshold disk size(Mbytes)</string>
 
+    <string name="pref_key_backend">pref.backend</string>
+    <string name="pref_title_backend">Choose Backend</string>
+    <string-array name="pref_entries_backend">
+        <item>Hexagon cDSP</item>
+        <item>Default ggml</item>
+    </string-array>
+    <string-array name="pref_entry_values_backend">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_entry_summaries_backend">
+        <item>offload GGML OP to cDSP directly</item>
+        <item>default ggml backend</item>
+    </string-array>
+
+    <string name="pref_key_llmthreadcounts">pref.llmthreadcounts</string>
+    <string name="pref_title_llmthreadcounts">Choose LLM thread counts</string>
+    <string-array name="pref_entries_llmthreadcounts">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+    </string-array>
+    <string-array name="pref_entry_values_llmthreadcounts">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+    </string-array>
+
+    <string name="pref_title_llm">LLM</string>
+    <string name="pref_key_llmmodel">pref.llmmodel</string>
+    <string name="pref_title_llmmodel">Choose LLM model</string>
+    <string-array name="pref_entries_llmmodel">
+        <item>Qwen1.5-1.8B</item>
+        <item>Qwen2.5-3B</item>
+        <item>Qwen3-4B</item>
+        <item>Qwen3-8B</item>
+        <item>Gemma3-4B</item>
+        <item>Gemma3-12B</item>
+    </string-array>
+    <string-array name="pref_entry_values_llmmodel">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+    </string-array>
+    <string-array name="pref_entry_summaries_llmmodel">
+        <item>Qwen1.5-1.8B</item>
+        <item>Qwen2.5-3B</item>
+        <item>Qwen3-4B</item>
+        <item>Qwen3-8B</item>
+        <item>Gemma3-4B</item>
+        <item>Gemma3-12B</item>
+    </string-array>
+
+    <string name="pref_title_LLMmodel"></string>
+    <string name="pref_key_downloadLLMmodel">pref.downloadLLMmodel</string>
+    <string name="pref_title_downloadLLMmodel">Download LLM model</string>
+    <string name="pref_summary_downloadLLMmodel">Download LLM model</string>
 
     <string name="pref_key_last_directory"></string>
 

--- a/android/kantvplayer/src/main/res/values/strings.xml
+++ b/android/kantvplayer/src/main/res/values/strings.xml
@@ -194,6 +194,8 @@
     <string name="play_history">Play History</string>
     <string name="performance_bechmark">Benchmark</string>
     <string name="asr_settings">ASR Setting</string>
+    <string name="llm_settings">LLM Setting</string>
+    <string name="hexagon_settings">Hexagon Setting</string>
     <string name="video_scan">Video Scan</string>
     <string name="general_question">Help</string>
     <string name="skin_nighttime">Night Mode</string>

--- a/android/kantvplayer/src/main/res/values/strings_pref.xml
+++ b/android/kantvplayer/src/main/res/values/strings_pref.xml
@@ -127,9 +127,10 @@
         <item>7</item>
     </string-array>
 
-    <string name="pref_key_ggmlmodel">pref.ggmlmodel</string>
-    <string name="pref_title_ggmlmodel">Choose GGML model</string>
-    <string-array name="pref_entries_ggmlmodel">
+    <string name="pref_title_asr">ASR</string>
+    <string name="pref_key_asrmodel">pref.asrmodel</string>
+    <string name="pref_title_asrmodel">Choose ASR model</string>
+    <string-array name="pref_entries_asrmodel">
         <item>tiny</item>
         <item>tiny.en</item>
         <item>tiny.en-q5_1</item>
@@ -147,7 +148,7 @@
         <item>medium.en-q5_0</item>
         <item>large</item>
     </string-array>
-    <string-array name="pref_entry_values_ggmlmodel">
+    <string-array name="pref_entry_values_asrmodel">
         <item>0</item>
         <item>1</item>
         <item>2</item>
@@ -165,7 +166,7 @@
         <item>14</item>
         <item>15</item>
     </string-array>
-    <string-array name="pref_entry_summaries_ggmlmodel">
+    <string-array name="pref_entry_summaries_asrmodel">
             <item>tiny</item>
             <item>tiny.en</item>
             <item>tiny.en-q5_1</item>
@@ -414,15 +415,9 @@
     <string name="pref_title_exitapp">Exit app </string>
     <string name="pref_summary_exitapp">click to exit app</string>
 
-    <string name="pref_title_ASRmodel"></string>
     <string name="pref_key_downloadASRmodel">pref.downloadASRmodel</string>
     <string name="pref_title_downloadASRmodel">Download ASR model</string>
     <string name="pref_summary_downloadASRmodel">Download ASR model</string>
-
-    <string name="pref_title_GGMLmodel"></string>
-    <string name="pref_key_downloadGGMLmodel">pref.downloadGGMLmodel</string>
-    <string name="pref_title_downloadGGMLmodel">Download GGML model</string>
-    <string name="pref_summary_downloadGGMLmodel">Download GGML model</string>
 
     <string name="pref_title_TTSmodel"></string>
     <string name="pref_key_downloadTTSmodel">pref.downloadTTSmodel</string>
@@ -514,6 +509,78 @@
     <string name="pref_title_record_thresholddisksize">threshold disk size</string>
     <string name="pref_summary_record_thresholddisksize" translatable="false">click to setting threshold disk size(Mbytes)</string>
 
+
+    <string name="pref_key_backend">pref.backend</string>
+    <string name="pref_title_backend">Choose Backend</string>
+    <string-array name="pref_entries_backend">
+        <item>Hexagon cDSP</item>
+        <item>Default ggml</item>
+    </string-array>
+    <string-array name="pref_entry_values_backend">
+        <item>0</item>
+        <item>1</item>
+    </string-array>
+    <string-array name="pref_entry_summaries_backend">
+        <item>offload GGML OP to cDSP directly</item>
+        <item>default ggml backend</item>
+    </string-array>
+
+    <string name="pref_title_llm">LLM</string>
+    <string name="pref_key_llmthreadcounts">pref.llmthreadcounts</string>
+    <string name="pref_title_llmthreadcounts">Choose LLM thread counts</string>
+    <string-array name="pref_entries_llmthreadcounts">
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+        <item>8</item>
+    </string-array>
+    <string-array name="pref_entry_values_llmthreadcounts">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+        <item>7</item>
+    </string-array>
+
+    <string name="pref_key_llmmodel">pref.llmmodel</string>
+    <string name="pref_title_llmmodel">Choose LLM model</string>
+    <string-array name="pref_entries_llmmodel">
+        <item>Qwen1.5-1.8B</item>
+        <item>Qwen2.5-3B</item>
+        <item>Qwen3-4B</item>
+        <item>Qwen3-8B</item>
+        <item>Gemma3-4B</item>
+        <item>Gemma3-12B</item>
+    </string-array>
+    <string-array name="pref_entry_values_llmmodel">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>4</item>
+        <item>5</item>
+        <item>6</item>
+    </string-array>
+    <string-array name="pref_entry_summaries_llmmodel">
+        <item>Qwen1.5-1.8B</item>
+        <item>Qwen2.5-3B</item>
+        <item>Qwen3-4B</item>
+        <item>Qwen3-8B</item>
+        <item>Gemma3-4B</item>
+        <item>Gemma3-12B</item>
+    </string-array>
+
+    <string name="pref_title_LLMmodel"></string>
+    <string name="pref_key_downloadLLMmodel">pref.downloadLLMmodel</string>
+    <string name="pref_title_downloadLLMmodel">Download LLM model</string>
+    <string name="pref_summary_downloadLLMmodel">Download LLM model</string>
 
     <string name="pref_key_last_directory"></string>
 

--- a/android/kantvplayer/src/main/res/xml/settings_llm.xml
+++ b/android/kantvplayer/src/main/res/xml/settings_llm.xml
@@ -4,21 +4,21 @@
 
     <PreferenceCategory android:title="@string/pref_title_general">
         <com.kantvai.kantvplayer.ui.fragment.settings.IjkListPreference
-            android:defaultValue="0"
-            android:entries="@@array/pref_entries_asrmode"
-            android:entryValues="@array/pref_entry_values_asrmode"
-            android:key="@string/pref_key_asrmode"
+            android:defaultValue="1"
+            android:entries="@@array/pref_entries_backend"
+            android:entryValues="@array/pref_entry_values_backend"
+            android:key="@string/pref_key_backend"
             android:persistent="true"
-            android:title="@string/pref_title_asrmode"
-            app:entrySummaries="@array/pref_entry_summaries_asrmode" />
+            android:title="@string/pref_title_backend"
+            app:entrySummaries="@array/pref_entry_summaries_backend" />
 
         <com.kantvai.kantvplayer.ui.fragment.settings.IjkListPreference
             android:defaultValue="3"
-            android:entries="@@array/pref_entries_asrthreadcounts"
-            android:entryValues="@array/pref_entry_values_asrthreadcounts"
-            android:key="@string/pref_key_asrthreadcounts"
+            android:entries="@@array/pref_entries_llmthreadcounts"
+            android:entryValues="@array/pref_entry_values_llmthreadcounts"
+            android:key="@string/pref_key_llmthreadcounts"
             android:persistent="true"
-            android:title="@string/pref_title_asrthreadcounts"
+            android:title="@string/pref_title_llmthreadcounts"
              />
 
         <!-- not implemented currently
@@ -33,24 +33,24 @@
         -->
     </PreferenceCategory>
 
-    <PreferenceCategory android:title="@string/pref_title_asr">
+    <PreferenceCategory android:title="LLM Model">
         <com.kantvai.kantvplayer.ui.fragment.settings.IjkListPreference
             android:defaultValue="0"
-            android:entries="@@array/pref_entries_asrmodel"
-            android:entryValues="@array/pref_entry_values_asrmodel"
-            android:key="@string/pref_key_asrmodel"
+            android:entries="@@array/pref_entries_llmmodel"
+            android:entryValues="@array/pref_entry_values_llmmodel"
+            android:key="@string/pref_key_llmmodel"
             android:persistent="true"
-            android:title="@string/pref_title_asrmodel"
-            app:entrySummaries="@array/pref_entry_summaries_asrmodel" />
+            android:title="@string/pref_title_llmmodel"
+            app:entrySummaries="@array/pref_entry_summaries_llmmodel" />
 
 
         <CheckBoxPreference
             android:defaultValue="true"
             android:enabled="true"
-            android:key="@string/pref_key_downloadASRmodel"
+            android:key="@string/pref_key_downloadLLMmodel"
             android:persistent="true"
-            android:summary="Download GGML model"
-            android:title="Download GGML model"
+            android:summary="@string/pref_summary_downloadLLMmodel"
+            android:title="@string/pref_title_downloadLLMmodel"
             android:widgetLayout="@layout/my_checkbox" />
     </PreferenceCategory>
 

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,0 +1,11 @@
+1. ASR not initialized
+
+this issue caused by Android permission: APK need to access storage to read/local ASR model.
+
+2. LLM download issue
+
+as well known, https://huggingface.co/ cann't be directly accessed from China.
+
+3. Be sure to review the [opening issues](https://github.com/zhouwg/kantv/issues?q=is%3Aopen+is%3Aissue) before contribute to project KanTV, We use [GitHub issues](https://github.com/zhouwg/kantv/issues) for tracking requests and bugs, please see [how to submit issue in this project ](https://github.com/zhouwg/kantv/issues/1).
+
+Report issue in various Android-based phone and <b>submit PR to this project is greatly welcomed</b>.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,11 +1,18 @@
-1. ASR not initialized
+How to troubleshooting issues in KanTV APK
 
-this issue caused by Android permission: APK need to access storage to read/local ASR model.
+1. "ASR not initialized" in realtime subtitle
 
-2. LLM download issue
+pls select the default ASR model "tiny.en-q8_0" in ASR Setting and re-launch the APK
+
+
+2. "ASR not initialized" in the "ggml-hexagon on Android"
+
+this issue caused by Android permission: APK need to access storage to read/load ASR model from path /sdcard/ in Android phone.
+
+pls re-launch the APK accordingly.
+
+3. LLM download issue
 
 as well known, https://huggingface.co/ cann't be directly accessed from China.
 
-3. Be sure to review the [opening issues](https://github.com/zhouwg/kantv/issues?q=is%3Aopen+is%3Aissue) before contribute to project KanTV, We use [GitHub issues](https://github.com/zhouwg/kantv/issues) for tracking requests and bugs, please see [how to submit issue in this project ](https://github.com/zhouwg/kantv/issues/1).
-
-Report issue in various Android-based phone and <b>submit PR to this project is greatly welcomed</b>.
+issue reports are greatly welcomed. Be sure to review the [opening issues](https://github.com/zhouwg/kantv/issues?q=is%3Aopen+is%3Aissue) before contribute to project KanTV, We use [GitHub issues](https://github.com/zhouwg/kantv/issues) for tracking requests and bugs, please see [how to submit issue in this project ](https://github.com/zhouwg/kantv/issues/1).

--- a/docs/build.md
+++ b/docs/build.md
@@ -193,3 +193,7 @@ cd kantv
 #### How to enable debug build
 
 Modify <a href="https://github.com/zhouwg/kantv/blob/master/android/kantvplayer/build.gradle#L17">kantvplayer/build.gradle</a> accordingly
+
+#### How to build project for Android phone equipped <b>without</b> Qualcomm mobile SoC
+
+modify [ggml/CMakeLists.txt#L12](https://github.com/zhouwg/kantv/blob/master/core/ggml/CMakeLists.txt#L12) accordingly.

--- a/docs/compliance-statement.md
+++ b/docs/compliance-statement.md
@@ -2,4 +2,8 @@
 
   The Android apk which built from the source codes of this project follows the principles of 'minimum permissions' and 'do not collect unnecessary user data'.Actually, the Android apk will <b>not collect any user data of upload any user data to server/cloud</b>.
 
-2.This project focus on device-AI tech and source code of libkantv-media.so will not be open-sourced currently because it contains proprietary IPR.
+2.This project is a <b>pure AI learning&study</b> project, so the Android APK is a <b>green</b> Android APP and will <b>NOT</b> collect/upload user data in Android device, following minimum permissions are required:
+  - Access to storage is required for TV recording(write recording data to storage) and ASR/LLM inference(read/load models from storage)
+  - Access to device information is required to obtain phone's network status information, distinguishing whether the current network is Wi-Fi or mobile when playing online TV
+
+3.This project focus on device-AI tech and source code of libkantv-media.so will not be open-sourced currently because it contains proprietary IPR.


### PR DESCRIPTION
### Purpose
- add LLM setting(for further usage/dev activity in real LLM inference on Android phone) and download LLM model in the APK. currently only support download the <b>built-in Gemma3-4B</b>(the reason can be found at:https://github.com/kantv-ai/kantv/pull/294).

- this feature may be only available outside of mainland China because of https://huggingface.co/ can't be directly accessed in there. issue reports with download LLM in the APK are greatly welcomed although I don't want to add extra/redundant codes to check whether the IP is come from mainland China and I think this issue might-be not difficult for developers/AI experts from mainland China(install a proxy in Android phone).

![Image](https://github.com/user-attachments/assets/025a8ff0-7584-4df2-97a5-f4e655a52e0f)
![Image](https://github.com/user-attachments/assets/b07f8560-9221-4136-b773-4b0874de294a)



