### PR TITLE
jni: refine JNI and try to improve stability of llava inference and stablediffusion inference in some corner cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,11 @@ KanTV("Kan", aka English "watch") , an open source project focus on study and pr
 
 - Well-maintained <b>turn-key / self-contained</b> workbench for AI beginners to learning on-device AI technology on Android.
 
-- Built-in [Gemma3-4B(text-to-text and image-to-text(multimodal))](https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/tree/main), [Gemma3-12B](https://huggingface.co/ggml-org/gemma-3-12b-it-GGUF/) , [Qwen1.5-1.8B](https://huggingface.co/Qwen/Qwen1.5-1.8B-Chat-GGUF), [Qwen2.5-3B](https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF), [Qwen2.5-VL-3B](https://huggingface.co/ggml-org/Qwen2.5-VL-3B-Instruct-GGUF), [Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B/tree/main), [Qwen3-8B](https://huggingface.co/Qwen/Qwen3-8B) supportive and runs entirely <b>offline(no Internet required)</b>. these LLM models can be downloadded in the Android APK directly without manually preparation. APK's users can compare the <b>real experience</b> of these LLM models on the Android phone.
+- Built-in [Gemma3-4B(text-to-text and image-to-text(multimodal))](https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/tree/main), [Gemma3-12B](https://huggingface.co/ggml-org/gemma-3-12b-it-GGUF/) , [Qwen1.5-1.8B](https://huggingface.co/Qwen/Qwen1.5-1.8B-Chat-GGUF), [Qwen2.5-3B](https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF), [Qwen2.5-VL-3B](https://huggingface.co/ggml-org/Qwen2.5-VL-3B-Instruct-GGUF), [Qwen3-4B](https://huggingface.co/Qwen/Qwen3-4B/tree/main), [Qwen3-8B](https://huggingface.co/Qwen/Qwen3-8B) supportive and runs entirely <b>offline(no Internet required)</b>. these LLM models can be downloadded in the Android APK directly without manually preparation(directly access to huggingface.co is required for this feature). APK's users can compare the <b>real experience</b> of these LLM models on the Android phone.
 
 - Text2Image on Android phone via the amazing [stable-diffusion.cpp](https://github.com/leejet/stable-diffusion.cpp).
 
-- Probably be the first [open-source implementation of a specified llama.cpp backend for Qualcomm Hexagon NPU](https://github.com/kantv-ai/kantv/blob/master/core/ggml/llamacpp/ggml/src/ggml-hexagon/ggml-hexagon.cpp) on Android phone.
+- Probably be the first [open-source implementation of a specified llama.cpp backend for Qualcomm Hexagon NPU](https://github.com/kantv-ai/kantv/blob/master/core/ggml/llamacpp/ggml/src/ggml-hexagon/ggml-hexagon.cpp) on Android phone, PR in the upstream llama.cpp community: https://github.com/ggml-org/llama.cpp/pull/12326
 
 ### Software architecture of KanTV Android
 

--- a/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIModel.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIModel.java
@@ -1,11 +1,11 @@
- /*
-  * Copyright (c) 2024- KanTV Authors
-  */
+/*
+ * Copyright (c) 2024- KanTV Authors
+ */
 package kantvai.ai;
 
- import kantvai.media.player.KANTVLog;
+import kantvai.media.player.KANTVLog;
 
- public class KANTVAIModel {
+public class KANTVAIModel {
      public enum AIModelType {
          TYPE_ASR,
          TYPE_TEXT2IMAGE,

--- a/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIModelMgr.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIModelMgr.java
@@ -1,18 +1,18 @@
- /*
-  * Copyright (c) 2024- KanTV Authors
-  */
- package kantvai.ai;
+/*
+ * Copyright (c) 2024- KanTV Authors
+ */
+package kantvai.ai;
 
- import kantvai.media.player.KANTVLog;
+import kantvai.media.player.KANTVLog;
 
- public class KANTVAIModelMgr {
+public class KANTVAIModelMgr {
      private static final String TAG = KANTVAIModelMgr.class.getSimpleName();
 
      private int defaultLLMModelIndex       = 4; //index of the default LLM model, default index is 4 (gemma-3-4b)
-     private final int LLM_MODEL_COUNTS     = 8; // counts of LLM models
+     private final int LLM_MODEL_COUNTS     = 8; // default counts of LLM models, might-be not the real counts of all LLM models
      private final int NON_LLM_MODEL_COUNTS = 2; // counts of non LLM models:1 ASR model ggml-tiny.en-q8_0.bin + 1 StableDiffusion model sd-v1-4.ckpt
 
-     private int capacity                   = LLM_MODEL_COUNTS + NON_LLM_MODEL_COUNTS;
+     private int capacity                   = LLM_MODEL_COUNTS + NON_LLM_MODEL_COUNTS; // default capacity of all AI models
 
 
      private KANTVAIModel[] AIModels;           //contains all LLM models + ASR model ggml-tiny.en-q8_0.bin + StableDiffusion model sd-v1-4.ckpt
@@ -127,6 +127,9 @@
          return arrayLLMModelsName;
      }
 
+     /*
+       return the real counts of all LLM models
+      */
      public int getLLMModelCounts() {
          return modelCounts - NON_LLM_MODEL_COUNTS;
      }
@@ -249,8 +252,8 @@
                  "https://huggingface.co/nvidia/Llama-3.1-Nemotron-Nano-8B-v1/tree/main");
 
 
-         modelCounts = modelIndex;
-         //initialize arrayModeName for UI
+         modelCounts = modelIndex;  //store to the real counts of all AI models
+         //initialize arrayModeName for UI AIResearchFragment.java to display all AI models(1 ASR model + 1 StableDiffusion model + all LLM models)
          arrayModelName = new String[modelCounts];
          for (int i = 0; i < modelCounts; i++) {
              arrayModelName[i] = AIModels[i].getNickname();
@@ -264,13 +267,13 @@
          //AIModels[defaultLLMModelIndex + NON_LLM_MODEL_COUNTS].setUrl("http://192.168.0.200/gemma-3-4b-it-Q8_0.gguf"); //download url of the LLM main model
          //AIModels[defaultLLMModelIndex + NON_LLM_MODEL_COUNTS].setMMprojUrl("http://192.168.0.200/mmproj-gemma3-4b-f16.gguf");//download url of the LLM mmproj model
 
-         //UT for download Qwen2.5-VL-3B from huggingface's mirror site in China, validate ok
+         //UT for download Qwen2.5-VL-3B from huggingface's mirror site, validate ok although it seems that this site is not stable
          //if (getKANTVAIModelFromName("Qwen2.5-VL-3B") != null) {
          //    getKANTVAIModelFromName("Qwen2.5-VL-3B").setUrl("https://hf-mirror.com/ggml-org/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf?download=true");
          //    getKANTVAIModelFromName("Qwen2.5-VL-3B").setMMprojUrl("https://hf-mirror.com/ggml-org/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-Qwen2.5-VL-3B-Instruct-Q8_0.gguf?download=true");
          //}
 
-         //UT for download Qwen3-14B from huggingface's mirror site in China, validate ok
+         //UT for download Qwen3-14B from huggingface's mirror site, validate ok although it seems that this site is not stable
          //if (getKANTVAIModelFromName("Qwen3-14B") != null) {
          //    getKANTVAIModelFromName("Qwen3-14B").setUrl("https://hf-mirror.com/Qwen/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf?download=true");
          //}

--- a/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIUtils.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIUtils.java
@@ -1,20 +1,257 @@
- /*
-  * Copyright (c) 2024- KanTV Authors
-  */
+/*
+ * Copyright (c) 2024- KanTV Authors
+ */
+ package kantvai.ai;
 
-package kantvai.ai;
+ import android.app.Activity;
+ import android.app.ActivityManager;
+ import android.content.Context;
+ import android.os.Build;
+ import android.os.Debug;
+
+ import java.util.concurrent.atomic.AtomicBoolean;
 
  import kantvai.media.player.KANTVLog;
 
  public final class KANTVAIUtils {
+     private final static String TAG                        = KANTVAIUtils.class.getName();
+
+     /**
+        whether ASR subsystem is initialized
+      */
+     private static AtomicBoolean mASRSubsystemInit         = new AtomicBoolean(false);
+
+     /**
+      * ASR mode
+      */
+     public static final int  ASR_MODE_NORMAL               = 0;     // transcription
+     public static final int  ASR_MODE_PRESURETEST          = 1;     // pressure test of asr subsystem
+     public static final int  ASR_MODE_BECHMARK             = 2;     // asr performance benchmark
+     public static final int  ASR_MODE_TRANSCRIPTION_RECORD = 3;     // transcription + audio record
+     private static int       mASRMode   = ASR_MODE_NORMAL;          // default ASR mode
+
+     //TODO: merge with AI bench_type
+     public static final int INFERENCE_ASR                  = 0;
+     public static final int INFERENCE_LLM                  = 1;
+     public static final  int INFERENCE_LLMAVA              = 2;
+     public static final  int INFERENCE_STABLEDIFUSSION     = 3;
+
 
     //this is experimental value to check whether a specified AI model has downloaded successfully
     // naive algorithm at the moment:
-    // if (real size of AI model - size of downloaded file == 1
+    // if (1 == (real size of AI model - size of downloaded file))
     //     download ok
     // if (real size of AI model - size of downloaded file > DOWNLOAD_SIZE_CHECK_RANGE)
     //     download failure
-    public static final long DOWNLOAD_SIZE_CHECK_RANGE = 700 * 1024 * 1024L;
+    public static final long DOWNLOAD_SIZE_CHECK_RANGE      = 700 * 1024 * 1024L;
+
+
+     //=============================================================================================
+     //add new AI benchmark type / new backend / new realtime inference type for GGML/NCNN here
+     //
+     //keep sync with ggml_jni_bench_type in ggml-jni.h & ncnn_jni_bench_type in ncnn-jni.h
+     public enum bench_type {
+         GGML_BENCHMARK_MEMCPY,                    //memcpy  benchmark
+         GGML_BENCHMARK_MULMAT,                    //mulmat  benchmark
+         GGML_BENCHMARK_ASR,                       //ASR(whisper.cpp) benchmark using GGML
+         GGML_BENCHMARK_LLM,                       //LLM(llama.cpp) benchmark using GGML
+         GGML_BENCHMARK_TEXT2IMAGE,                //TEXT2IMAGE(stablediffusion.cpp) benchmark using GGML
+         GGML_BENCHMARK_LLM_V,                     //A GPT-4V style Multimodal LLM benchmark using llama.cpp based on GGML
+         GGML_BENCHMARK_LLM_O,                     //A GPT-4o style Multimodal LLM benchmark using llama.cpp based on GGML
+
+         GGML_BENCHMARK_CV_MNIST,                  //MNIST inference using GGML
+         GGML_BENCHMARK_TTS,                       //TTS(bark.cpp) benchmark using GGML
+         GGML_BENCHMARK_MAX,                       //used for separate GGML and NCNN
+         NCNN_BENCHMARK_RESNET,
+         NCNN_BENCHMARK_SQUEEZENET,
+         NCNN_BENCHMARK_MNIST,
+         NCNN_BENCHMARK_ASR,
+         NCNN_BENCHMARK_TTS,
+         NCNN_BENCHARK_YOLOV5,
+         NCNN_BENCHARK_YOLOV10,
+         NCNN_BENCHMARK_MAX,
+     };
+
+     //keep sync with ncnn-jni.h, realtime inference with live camera / online TV using NCNN
+     public enum ncnn_realtimeinference_type {
+         NCNN_REALTIMEINFERENCE_FACEDETECT,
+         NCNN_REALTIMEINFERENCE_NANODAT,
+         NCNN_REALTIMEINFERENCE_YOLOV10
+     };
+     //keep sync with ncnn-jni.h, ncnn backend
+     public static final int NCNN_BACKEND_CPU           = 0;
+     public static final int NCNN_BACKEND_GPU           = 1;
+     //=============================================================================================
+
+     public static String getDeviceInfo(Activity activity, int inference_type) {
+         ActivityManager am = (ActivityManager) activity.getSystemService(Context.ACTIVITY_SERVICE);
+         ActivityManager.MemoryInfo memoryInfo = new ActivityManager.MemoryInfo();
+         am.getMemoryInfo(memoryInfo);
+         long totalMem = memoryInfo.totalMem;
+         long availMem = memoryInfo.availMem;
+         boolean isLowMemory = memoryInfo.lowMemory;
+         long threshold = memoryInfo.threshold;
+         Debug.MemoryInfo debugInfo = new Debug.MemoryInfo();
+         Debug.getMemoryInfo(debugInfo);
+         int totalPrivateClean = debugInfo.getTotalPrivateClean();
+         int totalPrivateDirty = debugInfo.getTotalPrivateDirty();
+         int totalPss = debugInfo.getTotalPss();
+         int totalSharedClean = debugInfo.getTotalSharedClean();
+         int totalSharedDirty = debugInfo.getTotalSharedDirty();
+         int totalSwappablePss = debugInfo.getTotalSwappablePss();
+         int totalUsageMemory = totalPrivateClean + totalPrivateDirty + totalPss + totalSharedClean + totalSharedDirty + totalSwappablePss;
+         int Bytes2MBytes = (1 << 20);
+         //VSS - Virtual Set Size
+         //RSS - Resident Set Size
+         //PSS - Proportional Set Size
+         //USS - Unique Set Size
+         String memoryInfoString =
+                 "total mem              ：" + (totalMem >> 20) + "MB" + "  "
+                         + "isLowMeory:" + isLowMemory + " "
+                         + "threshold of low mem：" + threshold / Bytes2MBytes + "MB" + "  "
+                         + "available mem：" + availMem / Bytes2MBytes + "MB" + " "
+                         + "NativeHeapSize：" + (Debug.getNativeHeapSize() >> 20) + "MB" + "  "
+                         + "NativeHeapAllocatedSize：" + (Debug.getNativeHeapAllocatedSize() >> 20) + "MB" + " "
+                         + "NativeHeapFreeSize：" + (Debug.getNativeHeapFreeSize() >> 20) + "MB " + " "
+                         + "total private dirty memory：" + totalPrivateDirty / 1024 + "MB" + " "
+                         + "total shared  dirty memory：" + totalSharedDirty / 1024 + "MB" + " "
+                         + "total PSS memory               ：" + totalPss / 1024 + "MB" + " "
+                         + "total swappable memory  ：" + totalSwappablePss / 1024 + "MB" + " "
+                         + "total usage memory           ：" + totalUsageMemory / 1024 + "MB" + " ";
+         KANTVLog.j(TAG, "memory info: " + memoryInfoString);
+
+         String systemInfo;
+         if (inference_type == INFERENCE_ASR)
+             systemInfo = ggmljava.asr_get_systeminfo();
+         else if (inference_type == INFERENCE_LLM)
+             systemInfo = ggmljava.llm_get_systeminfo();
+         else
+             systemInfo = "unknown system info of unsupported inference type:" + Integer.toString(inference_type) + " ";
+
+         String deviceInfo = "Device info:" + " "
+                 + Build.BRAND + " "
+                 + Build.HARDWARE + " "
+                 + "Android " + android.os.Build.VERSION.RELEASE + " "
+                 + "Arch:" + Build.CPU_ABI + " "
+                 + "(" + systemInfo + ")" + " "
+                 + "Mem:total " + (totalMem >> 20) + "MB"  + " "
+                 + "available " + (availMem >> 20) + "MB"   + " "
+                 + "usage " + (totalUsageMemory >> 10) + "MB";
+
+         return deviceInfo;
+     }
+
+     public static String getBenchmarkDesc(int benchmarkIndex) {
+         bench_type[] benchTypes = bench_type.values();
+         for (bench_type item : benchTypes) {
+             if (benchmarkIndex < bench_type.GGML_BENCHMARK_MAX.ordinal()) {
+                 if (item.ordinal() == benchmarkIndex) {
+                     return item.name();
+                 }
+             } else {
+                 if (item.ordinal() == benchmarkIndex + 1) {
+                     return item.name();
+                 }
+             }
+         }
+
+         return "unknown";
+     }
+
+     public static String getGGMLBackendDesc(int n_backend_type) {
+         switch (n_backend_type) {
+             case ggmljava.HEXAGON_BACKEND_QNNCPU:
+                 return "QNN-CPU";
+             case ggmljava.HEXAGON_BACKEND_QNNGPU:
+                 return "QNN-GPU";
+             case ggmljava.HEXAGON_BACKEND_QNNNPU:
+                 return "QNN-NPU";
+             case ggmljava.HEXAGON_BACKEND_CDSP:
+                 return "Hexagon-CDSP";
+             case ggmljava.HEXAGON_BACKEND_GGML:
+                 return "ggml";      //fake backend, just used to compare performance between Hexagon and original GGML
+             default:
+                 return "unknown";
+         }
+     }
+
+     public static String getNCNNBackendDesc(int n_backend_type) {
+         switch (n_backend_type) {
+             case 0:
+                 return "CPU";
+             case 1:
+                 return "GPU";
+             default:
+                 return "unknown";
+         }
+     }
+
+     public static String getASRModelString(int asrModelType) {
+         switch (asrModelType) {
+             case 0:
+                 return "tiny";
+             case 1:
+                 return "tiny.en";
+             case 2:
+                 return "tiny.en-q5_1";
+             case 3:
+                 return "tiny.en-q8_0";
+             case 4:
+                 return "tiny-q5_1";
+             case 5:
+                 return "base";
+             case 6:
+                 return "base.en";
+             case 7:
+                 return "base-q5_1";
+             case 8:
+                 return "small";
+             case 9:
+                 return "small.en";
+             case 10:
+                 return "small.en-q5_1";
+             case 11:
+                 return "small-q5_1";
+             case 12:
+                 return "medium";
+             case 13:
+                 return "medium.en";
+             case 14:
+                 return "medium.en-q5_0";
+             case 15:
+                 return "large";
+
+             default:
+                 return "unknown";
+         }
+     }
+
+     public static int getASRMode() {
+         return mASRMode;
+     }
+
+     public static String getASRModeString( int asrMode) {
+         switch (asrMode) {
+             case ASR_MODE_NORMAL:
+                 return "ASR_MODE_NORMAL";
+             case ASR_MODE_PRESURETEST:
+                 return "ASR_MODE_PRESURETEST";
+             case ASR_MODE_BECHMARK:
+                 return "ASR_MODE_BENCHAMRK";
+             case ASR_MODE_TRANSCRIPTION_RECORD:
+                 return "ASR_MODE_TRANSCRIPTION_RECORD";
+             default:
+                 return "unknown";
+         }
+     }
+
+     public static void setASRSubsystemInit(boolean bEnabled) {
+         mASRSubsystemInit.set(bEnabled);
+     }
+
+     public static boolean getASRSubsystemInit() {
+         return mASRSubsystemInit.get();
+     }
 
     //FIXME: should I move these helper functions to KANTVAIModelMgr.java?
     public static boolean isASRModel(String name) {

--- a/android/kantvplayer-lib/src/main/java/kantvai/ai/ggmljava.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/ai/ggmljava.java
@@ -1,7 +1,7 @@
  /*
   * Copyright (c) 2024- KanTV Authors
   */
- package kantvai.ai;
+package kantvai.ai;
 
 public class ggmljava {
     private static final String TAG = ggmljava.class.getName();
@@ -63,9 +63,15 @@ public class ggmljava {
      */
     public static native String llm_inference(String modelPath, String prompt, int nLLMType, int nThreadCounts, int nBackendType, int nHWAccelType);
 
-    public static native void    llm_stop_inference();
+    /**
+     * stop AI inference
+     */
+    public static native void    inference_stop_inference();
 
-    public static native boolean llm_is_running();
+    /**
+     * check whether AI inference is running
+     */
+    public static native boolean inference_is_running();
 
     /**
      * @param modelPath     /sdcard/xxxxxx.gguf

--- a/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVUtils.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/media/player/KANTVUtils.java
@@ -119,6 +119,7 @@
  import static kantvai.media.player.KANTVMediaType.MEDIA_TV;
  import androidx.annotation.Nullable;
 
+ import kantvai.ai.KANTVAIUtils;
  import kantvai.ai.ggmljava;
 
  public class KANTVUtils {
@@ -134,7 +135,7 @@
      private static String mApiGatewayServerUrl = "http://www.kantvai.com:8888/wiseplay/getlicense";
      private static String mLocalEMS = "http://192.168.0.200:81/ems";
 
-     private static String mKANTVAPKVersion = "1.6.3";
+     private static String mKANTVAPKVersion = "1.6.8";
      private static KANTVDRM mKANTVDRM = KANTVDRM.getInstance();
 
      public static final String INVALID_DEVICE_ID = "000000000000000";
@@ -255,18 +256,9 @@
      private static boolean mUsingFFmpegCodec = true; //using FFmpeg audio decoder for Exo2
      private static boolean mIsAPKForTV = false;
 
-     public static final int  ASR_MODE_NORMAL       = 0;     // transcription
-     public static final int  ASR_MODE_PRESURETEST  = 1;     // pressure test of asr subsystem
-     public static final int  ASR_MODE_BECHMARK     = 2;     // asr peformance benchamrk
-     public static final int  ASR_MODE_TRANSCRIPTION_RECORD = 3; // transcription + audio record
-     private static int       mASRMode = ASR_MODE_NORMAL;
-
-     public static final int INFERENCE_ASR          = 0;
-     public static final int INFERENCE_LLM          = 1;
-
      private static AtomicBoolean mCouldExitApp = new AtomicBoolean(true);
 
-     private static AtomicBoolean mASRSubsystemInit = new AtomicBoolean(false);
+
 
      //borrow from Google Exoplayer
      /**
@@ -3226,7 +3218,7 @@
      }
 
      public static void exitAPK(Activity activity) {
-         if (KANTVUtils.getASRSubsystemInit()) {
+         if (KANTVAIUtils.getASRSubsystemInit()) {
              ggmljava.asr_finalize();
          }
 
@@ -3995,218 +3987,6 @@
          KANTVLog.j(TAG, "memory info: " + memoryInfoString);
          return memoryInfoString;
      }
-
-     public static String getDeviceInfo(Activity activity, int inference_type) {
-         ActivityManager am = (ActivityManager) activity.getSystemService(Context.ACTIVITY_SERVICE);
-         ActivityManager.MemoryInfo memoryInfo = new ActivityManager.MemoryInfo();
-         am.getMemoryInfo(memoryInfo);
-         long totalMem = memoryInfo.totalMem;
-         long availMem = memoryInfo.availMem;
-         boolean isLowMemory = memoryInfo.lowMemory;
-         long threshold = memoryInfo.threshold;
-         Debug.MemoryInfo debugInfo = new Debug.MemoryInfo();
-         Debug.getMemoryInfo(debugInfo);
-         int totalPrivateClean = debugInfo.getTotalPrivateClean();
-         int totalPrivateDirty = debugInfo.getTotalPrivateDirty();
-         int totalPss = debugInfo.getTotalPss();
-         int totalSharedClean = debugInfo.getTotalSharedClean();
-         int totalSharedDirty = debugInfo.getTotalSharedDirty();
-         int totalSwappablePss = debugInfo.getTotalSwappablePss();
-         int totalUsageMemory = totalPrivateClean + totalPrivateDirty + totalPss + totalSharedClean + totalSharedDirty + totalSwappablePss;
-         int Bytes2MBytes = (1 << 20);
-         //VSS - Virtual Set Size
-         //RSS - Resident Set Size
-         //PSS - Proportional Set Size
-         //USS - Unique Set Size
-         String memoryInfoString =
-                 "total mem              ：" + (totalMem >> 20) + "MB" + "  "
-                         + "isLowMeory:" + isLowMemory + " "
-                         + "threshold of low mem：" + threshold / Bytes2MBytes + "MB" + "  "
-                         + "available mem：" + availMem / Bytes2MBytes + "MB" + " "
-                         + "NativeHeapSize：" + (Debug.getNativeHeapSize() >> 20) + "MB" + "  "
-                         + "NativeHeapAllocatedSize：" + (Debug.getNativeHeapAllocatedSize() >> 20) + "MB" + " "
-                         + "NativeHeapFreeSize：" + (Debug.getNativeHeapFreeSize() >> 20) + "MB " + " "
-                         + "total private dirty memory：" + totalPrivateDirty / 1024 + "MB" + " "
-                         + "total shared  dirty memory：" + totalSharedDirty / 1024 + "MB" + " "
-                         + "total PSS memory               ：" + totalPss / 1024 + "MB" + " "
-                         + "total swappable memory  ：" + totalSwappablePss / 1024 + "MB" + " "
-                         + "total usage memory           ：" + totalUsageMemory / 1024 + "MB" + " ";
-         KANTVLog.j(TAG, "memory info: " + memoryInfoString);
-
-         String systemInfo;
-         if (inference_type == INFERENCE_ASR)
-             systemInfo = ggmljava.asr_get_systeminfo();
-         else if (inference_type == INFERENCE_LLM)
-             systemInfo = ggmljava.llm_get_systeminfo();
-         else
-             systemInfo = "unknown system info of unsupported inference type:" + Integer.toString(inference_type) + " ";
-
-         String deviceInfo = "Device info:" + " "
-                 + Build.BRAND + " "
-                 + Build.HARDWARE + " "
-                 + "Android " + android.os.Build.VERSION.RELEASE + " "
-                 + "Arch:" + Build.CPU_ABI + " "
-                 + "(" + systemInfo + ")" + " "
-                 + "Mem:total " + (totalMem >> 20) + "MB"  + " "
-                 + "available " + (availMem >> 20) + "MB"   + " "
-                 + "usage " + (totalUsageMemory >> 10) + "MB";
-
-         return deviceInfo;
-     }
-
-     public static String getBenchmarkDesc(int benchmarkIndex) {
-         bench_type[] benchTypes = bench_type.values();
-         for (bench_type item : benchTypes) {
-             if (benchmarkIndex < bench_type.GGML_BENCHMARK_MAX.ordinal()) {
-                 if (item.ordinal() == benchmarkIndex) {
-                     return item.name();
-                 }
-             } else {
-                 if (item.ordinal() == benchmarkIndex + 1) {
-                     return item.name();
-                 }
-             }
-         }
-
-         return "unknown";
-     }
-
-
-     public static String getGGMLBackendDesc(int n_backend_type) {
-         switch (n_backend_type) {
-             case ggmljava.HEXAGON_BACKEND_QNNCPU:
-                 return "QNN-CPU";
-             case ggmljava.HEXAGON_BACKEND_QNNGPU:
-                 return "QNN-GPU";
-             case ggmljava.HEXAGON_BACKEND_QNNNPU:
-                 return "QNN-NPU";
-             case ggmljava.HEXAGON_BACKEND_CDSP:
-                 return "Hexagon-CDSP";
-             case ggmljava.HEXAGON_BACKEND_GGML:
-                 return "ggml";      //fake backend, just used to compare performance between Hexagon and original GGML
-             default:
-                 return "unknown";
-         }
-     }
-
-     public static String getNCNNBackendDesc(int n_backend_type) {
-         switch (n_backend_type) {
-             case 0:
-                 return "CPU";
-             case 1:
-                 return "GPU";
-             default:
-                 return "unknown";
-         }
-     }
-
-
-     public static String getASRModelString(int asrModelType) {
-         switch (asrModelType) {
-             case 0:
-                 return "tiny";
-             case 1:
-                 return "tiny.en";
-             case 2:
-                 return "tiny.en-q5_1";
-             case 3:
-                 return "tiny.en-q8_0";
-             case 4:
-                 return "tiny-q5_1";
-             case 5:
-                 return "base";
-             case 6:
-                 return "base.en";
-             case 7:
-                 return "base-q5_1";
-             case 8:
-                 return "small";
-             case 9:
-                 return "small.en";
-             case 10:
-                 return "small.en-q5_1";
-             case 11:
-                 return "small-q5_1";
-             case 12:
-                 return "medium";
-             case 13:
-                 return "medium.en";
-             case 14:
-                 return "medium.en-q5_0";
-             case 15:
-                 return "large";
-
-             default:
-                 return "unknown";
-         }
-     }
-
-
-     public static int getASRMode() {
-         return mASRMode;
-     }
-
-
-     public static String getASRModeString( int asrMode) {
-         switch (asrMode) {
-             case ASR_MODE_NORMAL:
-                 return "ASR_MODE_NORMAL";
-             case ASR_MODE_PRESURETEST:
-                 return "ASR_MODE_PRESURETEST";
-             case ASR_MODE_BECHMARK:
-                 return "ASR_MODE_BENCHAMRK";
-             case ASR_MODE_TRANSCRIPTION_RECORD:
-                 return "ASR_MODE_TRANSCRIPTION_RECORD";
-             default:
-                 return "unknown";
-         }
-     }
-
-     public static void setASRSubsystemInit(boolean bEnabled) {
-         mASRSubsystemInit.set(bEnabled);
-     }
-
-     public static boolean getASRSubsystemInit() {
-         return mASRSubsystemInit.get();
-     }
-
-
-     //=============================================================================================
-     //add new AI benchmark type / new backend / new realtime inference type for GGML/NCNN here
-     //
-     //keep sync with ggml-jni.h & ncnn-jni.h, bench type
-     public enum bench_type {
-         GGML_BENCHMARK_MEMCPY,                    //memcpy  benchmark
-         GGML_BENCHMARK_MULMAT,                    //mulmat  benchmark
-         GGML_BENCHMARK_ASR,                       //ASR(whisper.cpp) benchmark using GGML
-         GGML_BENCHMARK_LLM,                       //LLM(llama.cpp) benchmark using GGML
-         GGML_BENCHMARK_TEXT2IMAGE,                //TEXT2IMAGE(stablediffusion.cpp) benchmark using GGML
-         GGML_BENCHMARK_LLM_V,                     //A GPT-4V style Multimodal LLM benchmark using llama.cpp based on GGML
-         GGML_BENCHMARK_LLM_O,                     //A GPT-4o style Multimodal LLM benchmark using llama.cpp based on GGML
-
-         GGML_BENCHMARK_CV_MNIST,                  //MNIST inference using GGML
-         GGML_BENCHMARK_TTS,                       //TTS(bark.cpp) benchmark using GGML
-         GGML_BENCHMARK_MAX,                       //used for separate GGML and NCNN
-         NCNN_BENCHMARK_RESNET,
-         NCNN_BENCHMARK_SQUEEZENET,
-         NCNN_BENCHMARK_MNIST,
-         NCNN_BENCHMARK_ASR,
-         NCNN_BENCHMARK_TTS,
-         NCNN_BENCHARK_YOLOV5,
-         NCNN_BENCHARK_YOLOV10,
-         NCNN_BENCHMARK_MAX,
-     };
-
-     //keep sync with ncnn-jni.h, realtime inference with live camera / online TV using NCNN
-     public enum ncnn_realtimeinference_type {
-         NCNN_REALTIMEINFERENCE_FACEDETECT,
-         NCNN_REALTIMEINFERENCE_NANODAT,
-         NCNN_REALTIMEINFERENCE_YOLOV10
-     };
-     //keep sync with ncnn-jni.h, ncnn backend
-     public static final int NCNN_BACKEND_CPU           = 0;
-     public static final int NCNN_BACKEND_GPU           = 1;
-     //=============================================================================================
 
      public static byte[] loadContentFromFile(File file) {
          long beginTime = 0;

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/app/IApplication.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/app/IApplication.java
@@ -42,6 +42,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import cat.ereza.customactivityoncrash.config.CaocConfig;
+import kantvai.ai.KANTVAIUtils;
 import kantvai.ai.ggmljava;
 import kantvai.media.player.KANTVAssetLoader;
 import kantvai.media.player.KANTVLibraryLoader;
@@ -381,8 +382,8 @@ public class IApplication extends Application {
         int asrMode = mSettings.getASRMode();  //default is normal transcription
         int asrThreadCounts = mSettings.getASRThreadCounts(); //default is 4
         KANTVLog.j(TAG, "ASR model: " + mSettings.getASRModel());
-        KANTVLog.j(TAG, "ASR model name: " + KANTVUtils.getASRModelString(mSettings.getASRModel()));
-        String modelPath = KANTVUtils.getDataPath() + "ggml-" + KANTVUtils.getASRModelString(mSettings.getASRModel()) + ".bin";
+        KANTVLog.j(TAG, "ASR model name: " + KANTVAIUtils.getASRModelString(mSettings.getASRModel()));
+        String modelPath = KANTVUtils.getDataPath(mContext) + "ggml-" + KANTVAIUtils.getASRModelString(mSettings.getASRModel()) + ".bin";
         KANTVLog.j(TAG, "modelPath:" + modelPath);
 
         //preload GGML model and initialize asr_subsystem as early as possible for purpose of ASR real-time performance
@@ -391,16 +392,16 @@ public class IApplication extends Application {
             KANTVLibraryLoader.load("ggml-jni");
             KANTVLog.d(TAG, "cpu core counts:" + ggmljava.get_cpu_core_counts());
             KANTVLog.j(TAG, "asr mode: " + mSettings.getASRMode());
-            KANTVLog.g(TAG, "asr mode string: " + KANTVUtils.getASRModeString(mSettings.getASRMode()));
-            if ((KANTVUtils.ASR_MODE_NORMAL == mSettings.getASRMode()) || (KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD == mSettings.getASRMode())) {
-                result = ggmljava.asr_init(modelPath, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
+            KANTVLog.g(TAG, "asr mode string: " + KANTVAIUtils.getASRModeString(mSettings.getASRMode()));
+            if ((KANTVAIUtils.ASR_MODE_NORMAL == mSettings.getASRMode()) || (KANTVAIUtils.ASR_MODE_TRANSCRIPTION_RECORD == mSettings.getASRMode())) {
+                result = ggmljava.asr_init(modelPath, mSettings.getASRThreadCounts(), KANTVAIUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
             } else {
-                result = ggmljava.asr_init(modelPath, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_PRESURETEST, ggmljava.HEXAGON_BACKEND_GGML);
+                result = ggmljava.asr_init(modelPath, mSettings.getASRThreadCounts(), KANTVAIUtils.ASR_MODE_PRESURETEST, ggmljava.HEXAGON_BACKEND_GGML);
             }
             KANTVUtils.setASRConfig("whispercpp", modelPath, asrThreadCounts + 1, asrMode);
             KANTVUtils.setTVASR(false);
             if (0 == result) {
-                KANTVUtils.setASRSubsystemInit(true);
+                KANTVAIUtils.setASRSubsystemInit(true);
             } else {
                 KANTVLog.j(TAG, "********************************************\n");
                 KANTVLog.j(TAG, " pls check why failed to initialize ggml jni\n");

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/player/ffplayer/FFPlayerView.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/player/ffplayer/FFPlayerView.java
@@ -86,6 +86,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import kantvai.ai.KANTVAIUtils;
 import kantvai.ai.ggmljava;
 import kantvai.media.player.KANTVDRM;
 import kantvai.media.player.IMediaPlayer;
@@ -1532,7 +1533,7 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
             return;
         }
 
-        if (asrMode == KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD) {
+        if (asrMode == KANTVAIUtils.ASR_MODE_TRANSCRIPTION_RECORD) {
             KANTVLog.j(TAG, "asr saved filename:" + KANTVUtils.getASRSavedFileName());
         }
 
@@ -1540,7 +1541,7 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
         //String ggmlModelFileName = "ggml-tiny-q5_1.bin";      // 31M
         //String ggmlModelFileName = "ggml-tiny.en-q5_1.bin";   // 31M
         String ggmlModelFileName = "ggml-tiny.en-q8_0.bin";     // 42M, very good, about 500-700 ms
-        String userChooseModelName = KANTVUtils.getASRModelString(mSettings.getASRModel());
+        String userChooseModelName = KANTVAIUtils.getASRModelString(mSettings.getASRModel());
         String userChooseModelFileName = "ggml-" + userChooseModelName + ".bin";
         KANTVLog.j(TAG, "ggml model name of user's choose:" + userChooseModelFileName);
 
@@ -1555,7 +1556,7 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
         ggmlModelFileName = userChooseModelFileName;
         KANTVLog.j(TAG, "model: " + ggmlModelFileName);
 
-        File file = new File(KANTVUtils.getDataPath() + ggmlModelFileName);
+        File file = new File(KANTVUtils.getDataPath(mAppContext) + ggmlModelFileName);
         if (!file.exists()) {
             KANTVLog.j(TAG, "GGML model file not found:" + file.getAbsolutePath());
             Toast.makeText(getContext(), "GGML model file not found:" + file.getAbsolutePath(), Toast.LENGTH_SHORT).show();
@@ -1567,13 +1568,13 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
             KANTVLog.j(TAG, "ASR with GGML model file:" + file.getAbsolutePath());
         }
 
-        if (KANTVUtils.getASRSubsystemInit()) {
+        if (KANTVAIUtils.getASRSubsystemInit()) {
             int result = 0;
-            KANTVLog.j(TAG, "asr mode string: " + KANTVUtils.getASRModeString(mSettings.getASRMode()));
-            if ((KANTVUtils.ASR_MODE_NORMAL == mSettings.getASRMode()) || (KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD == mSettings.getASRMode())) {
-                result = ggmljava.asr_reset(KANTVUtils.getDataPath() + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
+            KANTVLog.j(TAG, "asr mode string: " + KANTVAIUtils.getASRModeString(mSettings.getASRMode()));
+            if ((KANTVAIUtils.ASR_MODE_NORMAL == mSettings.getASRMode()) || (KANTVAIUtils.ASR_MODE_TRANSCRIPTION_RECORD == mSettings.getASRMode())) {
+                result = ggmljava.asr_reset(KANTVUtils.getDataPath(mAppContext) + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVAIUtils.ASR_MODE_NORMAL, ggmljava.HEXAGON_BACKEND_GGML);
             } else {
-                result = ggmljava.asr_reset(KANTVUtils.getDataPath() + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVUtils.ASR_MODE_PRESURETEST, ggmljava.HEXAGON_BACKEND_GGML);
+                result = ggmljava.asr_reset(KANTVUtils.getDataPath(mAppContext) + ggmlModelFileName, mSettings.getASRThreadCounts(), KANTVAIUtils.ASR_MODE_PRESURETEST, ggmljava.HEXAGON_BACKEND_GGML);
             }
             if (0 == result) {
                 ggmljava.asr_start();
@@ -1595,7 +1596,7 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
         topBarView.updateTVASRVisibility(true);
 
         String tipInfo = "TV transcription will be launched.\n";
-        if (asrMode == KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD) {
+        if (asrMode == KANTVAIUtils.ASR_MODE_TRANSCRIPTION_RECORD) {
             tipInfo += "raw audio data would be saved to file for further usage:" + KANTVUtils.getASRSavedFileName();
         }
         showWarningDialog(mAttachActivity, tipInfo);
@@ -1618,7 +1619,7 @@ public class FFPlayerView extends FrameLayout implements PlayerViewListener {
         //ggmljava.asr_finalize();
         KANTVUtils.setTVASR(false);
         topBarView.updateTVASRVisibility(false);
-        if (asrMode == KANTVUtils.ASR_MODE_TRANSCRIPTION_RECORD) {
+        if (asrMode == KANTVAIUtils.ASR_MODE_TRANSCRIPTION_RECORD) {
             KANTVLog.j(TAG, "saved raw audio data file:" + KANTVUtils.getASRSavedFileName());
             File file = new File(KANTVUtils.getASRSavedFileName());
             if (file.exists()) {

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/AIResearchFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/AIResearchFragment.java
@@ -98,7 +98,7 @@
      private static final int SELECT_IMAGE = 1;
 
      private int nThreadCounts = 1;
-     private int nBenchmarkIndex = KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal();
+     private int nBenchmarkIndex = KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal();
      private int nPreviousBenchmakrIndex = 0;
      private String strModeName = "tiny.en-q8_0";
      private String strBackend = "ggml";
@@ -221,26 +221,26 @@
                  nBenchmarkIndex = Integer.valueOf(position);
                  KANTVLog.j(TAG, "benchmark index:" + nBenchmarkIndex);
 
-                 if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal()) {
+                 if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal()) {
                      spinnerModelName.setSelection(0); //hardcode to ggml-tiny.en-q8_0.bin for purpose of validate various models more easily on Android phone
                  }
-                 if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_LLM.ordinal()) {
+                 if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_LLM.ordinal()) {
                      //hardcode to gemma-3-4b-it-Q8_0.gguf for purpose of validate LLM multimodal more easily on Android phone
                      spinnerModelName.setSelection(AIModelMgr.getDefaultModelIndex() + AIModelMgr.getNonLLMModelCounts());
                      txtUserInput.setText("introduce the movie Once Upon a Time in America briefly, less then 100 words\n");
                  }
 
-                 if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_TEXT2IMAGE.ordinal()) {
+                 if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_TEXT2IMAGE.ordinal()) {
                      spinnerModelName.setSelection(1); //hardcode to SD model name for purpose of validate LLM multimodal more easily on Android phone
                      txtUserInput.setText("a lovely cat");
                  }
 
-                 if ((nPreviousBenchmakrIndex < KANTVUtils.bench_type.GGML_BENCHMARK_MAX.ordinal()) && (nBenchmarkIndex < KANTVUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())) {
+                 if ((nPreviousBenchmakrIndex < KANTVAIUtils.bench_type.GGML_BENCHMARK_MAX.ordinal()) && (nBenchmarkIndex < KANTVAIUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())) {
                      nPreviousBenchmakrIndex = nBenchmarkIndex;
                      return;
                  }
 
-                 if ((nPreviousBenchmakrIndex >= KANTVUtils.bench_type.GGML_BENCHMARK_MAX.ordinal()) && (nBenchmarkIndex >= KANTVUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())) {
+                 if ((nPreviousBenchmakrIndex >= KANTVAIUtils.bench_type.GGML_BENCHMARK_MAX.ordinal()) && (nBenchmarkIndex >= KANTVAIUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())) {
                      nPreviousBenchmakrIndex = nBenchmarkIndex;
                      return;
                  }
@@ -256,7 +256,7 @@
 
              }
          });
-         spinnerBenchType.setSelection(KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal());
+         spinnerBenchType.setSelection(KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal());
 
          Spinner spinnerThreadsCounts = mActivity.findViewById(R.id.spinnerThreadCounts);
          String[] arrayThreadCounts = getResources().getStringArray(R.array.threadCounts);
@@ -321,6 +321,7 @@
          spinnerModelName.setSelection(0); // ggml-tiny.en-q8_0.bin, 42M
 
          btnSelectImage.setOnClickListener(v -> {
+             resetUIAndStatus(null, true, false);
              Intent intent = new Intent(Intent.ACTION_PICK);
              intent.setType("image/*");
              startActivityForResult(intent, SELECT_IMAGE);
@@ -328,9 +329,9 @@
 
          btnStop.setOnClickListener(v -> {
              KANTVLog.g(TAG, "here");
-             if (ggmljava.llm_is_running()) {
+             if (ggmljava.inference_is_running()) {
                  KANTVLog.g(TAG, "here");
-                 ggmljava.llm_stop_inference();
+                 ggmljava.inference_stop_inference();
              }
              resetUIAndStatus(null,true, false);
          });
@@ -339,7 +340,7 @@
              KANTVLog.g(TAG, "selectUIIndex:" + selectedUIIndex);
              KANTVLog.g(TAG, "selectModeIndex:" + selectModelIndex);
              KANTVLog.g(TAG, "strModeName:" + arrayModelName[selectedUIIndex]);
-             KANTVLog.j(TAG, "exec ggml benchmark: type: " + KANTVUtils.getBenchmarkDesc(nBenchmarkIndex)
+             KANTVLog.j(TAG, "exec ggml benchmark: type: " + KANTVAIUtils.getBenchmarkDesc(nBenchmarkIndex)
                      + ", threads:" + nThreadCounts + ", model:" + strModeName + ", backend:" + strBackend);
              String selectModelFilePath = "";
 
@@ -348,7 +349,7 @@
              //sanity check begin
              {
                  isASRModel = KANTVAIUtils.isASRModel(strModeName);
-                 if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_LLM.ordinal()) {
+                 if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_LLM.ordinal()) {
                      //attention here
                      if (selectModelIndex < 0) {
                          selectModelIndex = 0;
@@ -357,7 +358,7 @@
                          selectModeFileName = AIModelMgr.getKANTVAIModelFromName(strModeName).getName();
                      }
                      isLLMModel = true;
-                 } else if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_TEXT2IMAGE.ordinal()) {
+                 } else if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_TEXT2IMAGE.ordinal()) {
                      isSDModel = true;
                      selectModeFileName = AIModelMgr.getKANTVAIModelFromName(strModeName).getName();
                  } else {
@@ -367,19 +368,19 @@
                  setTextGGMLInfo(selectModeFileName);
                  KANTVLog.g(TAG, "selectModeFileName:" + selectModeFileName);
 
-                 if ((KANTVUtils.bench_type.GGML_BENCHMARK_MEMCPY.ordinal() == nBenchmarkIndex)
-                         || (KANTVUtils.bench_type.GGML_BENCHMARK_MULMAT.ordinal() == nBenchmarkIndex)) {
+                 if ((KANTVAIUtils.bench_type.GGML_BENCHMARK_MEMCPY.ordinal() == nBenchmarkIndex)
+                         || (KANTVAIUtils.bench_type.GGML_BENCHMARK_MULMAT.ordinal() == nBenchmarkIndex)) {
                      //reset to ASR model name
                      setTextGGMLInfo(AIModelMgr.getKANTVAIModelFromIndex(0).getName());
                  } else {
-                     if (isASRModel && (nBenchmarkIndex != KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal())) {
-                         KANTVLog.j(TAG, "1-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVUtils.getBenchmarkDesc(nBenchmarkIndex));
-                         KANTVUtils.showMsgBox(mActivity, "1-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVUtils.getBenchmarkDesc(nBenchmarkIndex));
+                     if (isASRModel && (nBenchmarkIndex != KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal())) {
+                         KANTVLog.j(TAG, "1-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVAIUtils.getBenchmarkDesc(nBenchmarkIndex));
+                         KANTVUtils.showMsgBox(mActivity, "1-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVAIUtils.getBenchmarkDesc(nBenchmarkIndex));
                          return;
                      }
-                     if ((!isASRModel) && (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal())) {
-                         KANTVLog.j(TAG, "2-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVUtils.getBenchmarkDesc(nBenchmarkIndex));
-                         KANTVUtils.showMsgBox(mActivity, "2-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVUtils.getBenchmarkDesc(nBenchmarkIndex));
+                     if ((!isASRModel) && (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal())) {
+                         KANTVLog.j(TAG, "2-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVAIUtils.getBenchmarkDesc(nBenchmarkIndex));
+                         KANTVUtils.showMsgBox(mActivity, "2-mismatch between model file:" + selectModeFileName + " and bench type: " + KANTVAIUtils.getBenchmarkDesc(nBenchmarkIndex));
                          return;
                      }
                  }
@@ -417,10 +418,11 @@
                  }
 
                  if (isASRModel) //ASR inference
-                     //ASR inference: built-in ASR model which located in path /sdcard/kantv/
-                     selectModelFilePath = KANTVUtils.getDataPath() + selectModeFileName;
+                     //ASR inference: built-in ASR model which located in path /sdcard/kantv/ or internal data path
+                     selectModelFilePath = KANTVUtils.getDataPath(mContext) + selectModeFileName;
                  else {
-                     //LLM inference: LLM model is located on /sdcard/ and manually uploaded by user currently
+                     //LLM inference: LLM model is located on /sdcard/ and can be downloaded in the APK,
+                     //               or manually uploaded to the phone by user
                      selectModelFilePath = KANTVUtils.getSDCardDataPath() + selectModeFileName;
                  }
 
@@ -473,7 +475,7 @@
              ggmlModelFileName = selectModelFilePath;
              KANTVLog.j(TAG, "model file:" + ggmlModelFileName);
              if (isASRModel) { //avoid crash
-                 int result = ggmljava.asr_reset(selectModelFilePath, ggmljava.get_cpu_core_counts() / 2, KANTVUtils.ASR_MODE_BECHMARK, backendIndex);
+                 int result = ggmljava.asr_reset(selectModelFilePath, ggmljava.get_cpu_core_counts() / 2, KANTVAIUtils.ASR_MODE_BECHMARK, backendIndex);
                  if (0 != result) {
                      KANTVLog.j(TAG, "failed to initialize ASR, pls restart APP before ensure necessary permission has granted to APP and ensure select tiny.en-q8_0 in ASR Setting");
                      KANTVUtils.showMsgBox(mActivity, "failed to initialize ASR, pls restart APP before ensure necessary permission has granted to APP and ensure select tiny.en-q8_0 in ASR Setting");
@@ -721,7 +723,7 @@
                      return;
                  }
 
-                 if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal()) {
+                 if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal()) {
                      if (content.contains("not initialized")) {
                          bASROK = false;
                      }
@@ -753,8 +755,8 @@
                              //txtASRInfo.setText("");
                              nLogCounts = 0;
                          }
-                         if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_LLM.ordinal()) {
-                             if (!ggmljava.llm_is_running()) {
+                         if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_LLM.ordinal()) {
+                             if (!ggmljava.inference_is_running()) {
                                  return;
                              }
                          }
@@ -799,8 +801,8 @@
          if (mKANTVMgr == null) {
              return;
          }
-         if (ggmljava.llm_is_running()) {
-             ggmljava.llm_stop_inference();
+         if (ggmljava.inference_is_running()) {
+             ggmljava.inference_stop_inference();
          }
 
          try {
@@ -819,8 +821,8 @@
      }
 
      public void stopLLMInference() {
-         if (ggmljava.llm_is_running()) {
-             ggmljava.llm_stop_inference();
+         if (ggmljava.inference_is_running()) {
+             ggmljava.inference_stop_inference();
          }
 
          resetUIAndStatus(null,true, false);
@@ -851,14 +853,14 @@
      */
 
      private boolean isGGMLInfernce() {
-         if (nBenchmarkIndex < KANTVUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())
+         if (nBenchmarkIndex < KANTVAIUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())
              return true;
          else
              return false;
      }
 
      private boolean isNCNNInference() {
-         if (nBenchmarkIndex >= KANTVUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())
+         if (nBenchmarkIndex >= KANTVAIUtils.bench_type.GGML_BENCHMARK_MAX.ordinal())
              return true;
          else
              return false;
@@ -971,6 +973,8 @@
                  llInfoLayout.removeView(ivInfo);
                  ivInfo = null;
              }
+             bitmapSelectedImage = null;
+             pathSelectedImage = null;
          } else {
              if (isMNISTModel) {
                  String imgPath = KANTVUtils.getDataPath() + ggmlMNISTImageFile;
@@ -1008,8 +1012,8 @@
      }
 
      private String getBenchmarkTip() {
-         String backendDesc = KANTVUtils.getGGMLBackendDesc(backendIndex);
-         String benchmarkTip = "\nBench:" + KANTVUtils.getBenchmarkDesc(nBenchmarkIndex) + " (model: " + selectModeFileName
+         String backendDesc = KANTVAIUtils.getGGMLBackendDesc(backendIndex);
+         String benchmarkTip = "\nBench:" + KANTVAIUtils.getBenchmarkDesc(nBenchmarkIndex) + " (model: " + selectModeFileName
                  + " ,threads: " + nThreadCounts
                  + " ,backend: " + backendDesc
                  + " ) cost " + duration + " milliseconds";
@@ -1030,7 +1034,7 @@
          if (strBenchmarkInfo.startsWith("unknown")) {
              return;
          }
-         String backendDesc = KANTVUtils.getGGMLBackendDesc(backendIndex);
+         String backendDesc = KANTVAIUtils.getGGMLBackendDesc(backendIndex);
          /*
          String benchmarkTip = "\nBench:" + KANTVUtils.getBenchmarkDesc(nBenchmarkIndex) + " (model: " + selectModeFileName
                  + " ,threads: " + nThreadCounts
@@ -1053,7 +1057,7 @@
              }
          }
 
-         if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal()) {
+         if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal()) {
              if (!bASROK) {
                  return;
              }
@@ -1065,10 +1069,10 @@
          KANTVLog.j(TAG, benchmarkTip);
          String dispInfo;
          if (!bOnlyDisplayBenchmarkTip) { //compatible with previous showMsgBox
-             if (nBenchmarkIndex == KANTVUtils.bench_type.GGML_BENCHMARK_ASR.ordinal())
-                 dispInfo = KANTVUtils.getDeviceInfo(mActivity, KANTVUtils.INFERENCE_ASR);
+             if (nBenchmarkIndex == KANTVAIUtils.bench_type.GGML_BENCHMARK_ASR.ordinal())
+                 dispInfo = KANTVAIUtils.getDeviceInfo(mActivity, KANTVAIUtils.INFERENCE_ASR);
              else
-                 dispInfo = KANTVUtils.getDeviceInfo(mActivity, KANTVUtils.INFERENCE_LLM);
+                 dispInfo = KANTVAIUtils.getDeviceInfo(mActivity, KANTVAIUtils.INFERENCE_LLM);
              dispInfo += "\n\n";
 
              dispInfo += benchmarkTip;
@@ -1089,7 +1093,7 @@
 
      private void setTextGGMLInfo(String LLMModelFileName) {
          txtGGMLInfo.setText("");
-         txtGGMLInfo.append(KANTVUtils.getDeviceInfo(mActivity, KANTVUtils.INFERENCE_ASR));
+         txtGGMLInfo.append(KANTVAIUtils.getDeviceInfo(mActivity, KANTVAIUtils.INFERENCE_ASR));
          txtGGMLInfo.append("\n" + "AI model:" + LLMModelFileName);
          String timestamp = "";
          SimpleDateFormat fullDateFormat = new SimpleDateFormat("yyyy-MM-dd,HH:mm:ss");

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/LLMResearchFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/LLMResearchFragment.java
@@ -42,6 +42,7 @@
 
  import butterknife.BindView;
  import kantvai.ai.KANTVAIModelMgr;
+ import kantvai.ai.KANTVAIUtils;
  import kantvai.ai.ggmljava;
  import kantvai.media.player.KANTVEvent;
  import kantvai.media.player.KANTVEventListener;
@@ -54,7 +55,7 @@
 
 
  //the feature in this UI page is exactly similar to AIResearchFragment.java
- //keep it for further usage
+ //keep it for further usage(realtime LLM inference on Android phone: voice input ---> ASR ---> LLM ---> TTS)
  public class LLMResearchFragment extends BaseMvpFragment<LLMResearchPresenter> implements LLMResearchView {
      @BindView(R.id.llmresearchLayout)
      LinearLayout layout;
@@ -200,9 +201,9 @@
 
          btnStopInference.setOnClickListener(v -> {
              KANTVLog.g(TAG, "here");
-             if (ggmljava.llm_is_running()) {
+             if (ggmljava.inference_is_running()) {
                  KANTVLog.g(TAG, "here");
-                 ggmljava.llm_stop_inference();
+                 ggmljava.inference_stop_inference();
              }
              restoreUIAndStatus();
          });
@@ -340,7 +341,7 @@
                              nLogCounts = 0;
                          }
 
-                         if (!ggmljava.llm_is_running()) {
+                         if (!ggmljava.inference_is_running()) {
                              return;
                          }
 
@@ -384,8 +385,8 @@
          if (mKANTVMgr == null) {
              return;
          }
-         if (ggmljava.llm_is_running()) {
-             ggmljava.llm_stop_inference();
+         if (ggmljava.inference_is_running()) {
+             ggmljava.inference_stop_inference();
          }
 
          try {
@@ -404,8 +405,8 @@
      }
 
      public void stopLLMInference() {
-         if (ggmljava.llm_is_running()) {
-             ggmljava.llm_stop_inference();
+         if (ggmljava.inference_is_running()) {
+             ggmljava.inference_stop_inference();
          }
 
          restoreUIAndStatus();
@@ -442,7 +443,7 @@
              restoreUIAndStatus();
              return;
          }
-         String backendDesc = KANTVUtils.getGGMLBackendDesc(backendIndex);
+         String backendDesc = KANTVAIUtils.getGGMLBackendDesc(backendIndex);
 
          String benchmarkTip =  " (model: " + LLMModelFullName
                  + " ,threads: " + nThreadCounts
@@ -463,7 +464,7 @@
 
          String dispInfo;
 
-         dispInfo = KANTVUtils.getDeviceInfo(mActivity, KANTVUtils.INFERENCE_LLM);
+         dispInfo = KANTVAIUtils.getDeviceInfo(mActivity, KANTVAIUtils.INFERENCE_LLM);
          dispInfo += "\n\n";
 
          benchmarkTip += "\n";
@@ -491,7 +492,7 @@
      }
      private void setTextGGMLInfo(String LLMModelFullName) {
          txtGGMLInfo.setText("");
-         txtGGMLInfo.append(KANTVUtils.getDeviceInfo(mActivity, KANTVUtils.INFERENCE_LLM));
+         txtGGMLInfo.append(KANTVAIUtils.getDeviceInfo(mActivity, KANTVAIUtils.INFERENCE_LLM));
          txtGGMLInfo.append("\n" + "LLM model:" + LLMModelFullName);
          String timestamp = "";
          SimpleDateFormat fullDateFormat = new SimpleDateFormat("yyyy-MM-dd,HH:mm:ss");

--- a/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/settings/ASRSettingFragment.java
+++ b/android/kantvplayer/src/main/java/com/kantvai/kantvplayer/ui/fragment/settings/ASRSettingFragment.java
@@ -26,6 +26,7 @@
 
  import java.io.File;
 
+ import kantvai.ai.KANTVAIUtils;
  import kantvai.media.player.KANTVLog;
  import kantvai.media.player.KANTVUtils;
 
@@ -115,8 +116,8 @@
                  KANTVLog.j(TAG, "asrmode: " + mSettings.getASRMode());
                  KANTVLog.j(TAG, "asrthreadCounts " + mSettings.getASRThreadCounts());
                  KANTVLog.j(TAG, "ASR model: " + mSettings.getASRModel());
-                 KANTVLog.j(TAG, "ASR model name: " + KANTVUtils.getASRModelString(mSettings.getASRModel()));
-                 String modelPath = KANTVUtils.getDataPath() + "ggml-" + KANTVUtils.getASRModelString(mSettings.getASRModel()) + ".bin";
+                 KANTVLog.j(TAG, "ASR model name: " + KANTVAIUtils.getASRModelString(mSettings.getASRModel()));
+                 String modelPath = KANTVUtils.getDataPath() + "ggml-" + KANTVAIUtils.getASRModelString(mSettings.getASRModel()) + ".bin";
                  KANTVLog.j(TAG, "modelPath:" + modelPath);
                  KANTVUtils.setASRConfig("whispercpp", modelPath, mSettings.getASRThreadCounts(), mSettings.getASRMode());
              }
@@ -143,7 +144,7 @@
 
              String asrAudioFileName = KANTVUtils.getDataPath() + "jfk.wav";
              //String asrModelFileName = KANTVUtils.getDataPath(mContext) + "ggml-tiny.en-q8_0.bin";
-             String userChooseModelName = KANTVUtils.getASRModelString(mSettings.getASRModel());
+             String userChooseModelName = KANTVAIUtils.getASRModelString(mSettings.getASRModel());
              KANTVLog.g(TAG, "ASR model name of user choose:" + userChooseModelName);
              String userChooseModelFileName = "ggml-" + userChooseModelName + ".bin";
              File asrAudioFile = new File(asrAudioFileName);

--- a/core/ggml/jni/ggml-jni-impl-external.cpp
+++ b/core/ggml/jni/ggml-jni-impl-external.cpp
@@ -7419,20 +7419,33 @@ const char * ggml_backend_hexagon_get_devname(size_t dev_num) {
 }
 #endif
 
-static static std::atomic<uint32_t> g_ggmljni_llm_is_running(0);
+static static std::atomic<uint32_t> g_ggmljni_inference_is_running(0);
 
-void llama_init_running_state() {
-    g_ggmljni_llm_is_running.store(1);
+/**
+*helper functions to check whether AI inference is running, these helper functions is useful&necessary for UI in Java layer
+*/
+void inference_init_running_state() {
+    g_ggmljni_inference_is_running.store(1);
 }
 
-void llama_reset_running_state() {
-    g_ggmljni_llm_is_running.store(0);
+void inference_reset_running_state() {
+    g_ggmljni_inference_is_running.store(0);
 }
 
-int llama_is_running_state() {
-    return g_ggmljni_llm_is_running.load();
+int inference_is_running_state() {
+    return g_ggmljni_inference_is_running.load();
 }
 
+/**
+ * helper function to performan llama inference in native layer
+ * @param sz_model_path
+ * @param sz_user_data
+ * @param llm_type
+ * @param n_threads
+ * @param n_backend_type
+ * @param n_hwaccel_type
+ * @return
+ */
 int llama_inference(const char * sz_model_path, const char * sz_user_data, int llm_type,
                        int n_threads, int n_backend_type, int n_hwaccel_type) {
     int ret = 0;
@@ -7456,14 +7469,25 @@ int llama_inference(const char * sz_model_path, const char * sz_user_data, int l
                           "-p", sz_user_data,
                           "-t", std::to_string(n_threads).c_str()
     };
-    llama_init_running_state();
+    inference_init_running_state();
     ret = llama_inference_main(argc, const_cast<char **>(argv), n_backend_type);
-    llama_reset_running_state();
+    inference_reset_running_state();
 
     return ret;
 }
 
-
+/**
+ * helper function to performan llava(multimodal) inference in native layer
+ * @param sz_model_path
+ * @param sz_mmproj_model_path
+ * @param img_path
+ * @param sz_user_data
+ * @param llm_type
+ * @param n_threads
+ * @param n_backend_type
+ * @param n_hwaccel_type
+ * @return
+ */
 int llava_inference(const char *sz_model_path, const char *sz_mmproj_model_path, const char * img_path, const char *sz_user_data, int llm_type,
                        int n_threads, int n_backend_type, int n_hwaccel_type) {
     int ret = 0;
@@ -7494,14 +7518,25 @@ int llava_inference(const char *sz_model_path, const char *sz_mmproj_model_path,
                           "-p", sz_user_data,
                           "-t", std::to_string(n_threads).c_str()
     };
-    llama_init_running_state();
+    inference_init_running_state();
     ret = llava_inference_main(argc, const_cast<char **>(argv), n_backend_type);
-    llama_reset_running_state();
+    inference_reset_running_state();
 
     LOGGD("ret %d", ret);
     return ret;
 }
 
+/**
+ * helper function to perform stable-diffusion inference in native layer
+ * @param sz_model_path
+ * @param sz_aux_model_path
+ * @param sz_user_data
+ * @param llm_type
+ * @param n_threads
+ * @param n_backend_type
+ * @param n_hwaccel_type
+ * @return
+ */
 int sd_inference(const char *sz_model_path, const char *sz_aux_model_path, const char *sz_user_data, int llm_type,
                     int n_threads, int n_backend_type, int n_hwaccel_type) {
     int ret = 0;
@@ -7530,7 +7565,9 @@ int sd_inference(const char *sz_model_path, const char *sz_aux_model_path, const
                           "--height", "64",
                           "-t", std::to_string(n_threads).c_str()
     };
+    inference_init_running_state();
     ret = sd_inference_main(argc, argv, n_backend_type);
+    inference_reset_running_state();
     LOGGD("ret %d", ret);
     return ret;
 }

--- a/core/ggml/jni/ggml-jni.c
+++ b/core/ggml/jni/ggml-jni.c
@@ -267,7 +267,7 @@ Java_kantvai_ai_ggmljava_llm_1inference(JNIEnv * env, jclass clazz, jstring mode
     result = llama_inference(sz_model_path, sz_prompt, n_llm_type, n_thread_counts, n_backend, n_hwaccel_type);
     LOGGD("result %d", result);
     if (0 != result) {
-        if (result != LLM_INFERENCE_INTERRUPTED) {
+        if (result != AI_INFERENCE_INTERRUPTED) {
             GGML_JNI_NOTIFY("LLM inference with backend %d failure", n_backend);
         }
     }
@@ -294,20 +294,20 @@ void  ggml_jni_notify_c_impl(const char * format,  ...) {
     memset(s_ggml_jni_buf, 0, JNI_BUF_LEN);
     va_start(va, format);
     len_content = vsnprintf(s_ggml_jni_buf, JNI_BUF_LEN, format, va);
-    snprintf(s_ggml_jni_buf + len_content, JNI_BUF_LEN - len_content, "\n");
+    //snprintf(s_ggml_jni_buf + len_content, JNI_BUF_LEN - len_content, "\n");
     va_end(va);
 
     kantv_asr_notify_benchmark_c(s_ggml_jni_buf);
 }
 
 JNIEXPORT void JNICALL
-Java_kantvai_ai_ggmljava_llm_1stop_1inference(JNIEnv * env, jclass clazz) {
-    llama_reset_running_state();
+Java_kantvai_ai_ggmljava_inference_1stop_1inference(JNIEnv * env, jclass clazz) {
+    inference_reset_running_state();
 }
 
 JNIEXPORT jboolean JNICALL
-Java_kantvai_ai_ggmljava_llm_1is_1running(JNIEnv * env, jclass clazz) {
-    if (1 == llama_is_running_state()) {
+Java_kantvai_ai_ggmljava_inference_1is_1running(JNIEnv * env, jclass clazz) {
+    if (1 == inference_is_running_state()) {
         return JNI_TRUE;
     } else {
         return JNI_FALSE;
@@ -374,8 +374,8 @@ Java_kantvai_ai_ggmljava_llava_1inference(JNIEnv * env, jclass clazz, jstring mo
     result = llava_inference(sz_model_path, sz_mmproj_path, sz_img_path, sz_prompt, n_llmtype, n_thread_counts, n_backend_type, n_hwaccel_type);
     LOGGD("result %d", result);
     if (0 != result) {
-        if (result != LLM_INFERENCE_INTERRUPTED) {
-            GGML_JNI_NOTIFY("LLM inference with backend %d failure", n_backend_type);
+        if (result != AI_INFERENCE_INTERRUPTED) {
+            GGML_JNI_NOTIFY("LLAVA inference with backend %d failure", n_backend_type);
         }
     }
 
@@ -453,8 +453,8 @@ Java_kantvai_ai_ggmljava_stablediffusion_1inference(JNIEnv *env, jclass clazz, j
     result = sd_inference(sz_model_path, sz_auxmodel_path, sz_prompt, n_llmtype, n_thread_counts, n_backend_type, n_hwaccel_type);
     LOGGD("result %d", result);
     if (0 != result) {
-        if (result != LLM_INFERENCE_INTERRUPTED) {
-            GGML_JNI_NOTIFY("LLM inference with backend %d failure", n_backend_type);
+        if (result != AI_INFERENCE_INTERRUPTED) {
+            GGML_JNI_NOTIFY("StableDiffusion inference with backend %d failure", n_backend_type);
         }
     }
 

--- a/core/ggml/jni/ggml-jni.h
+++ b/core/ggml/jni/ggml-jni.h
@@ -21,9 +21,13 @@
 extern "C" {
 #endif
 
-#define LLM_INFERENCE_INTERRUPTED             8
+/**
+ * AI inference in native layer was stopped/interrupted from Java layer
+ */
+#define AI_INFERENCE_INTERRUPTED             8
+
 //=============================================================================================
-//add new AI benchmark type / new backend using GGML inference framework here, keep sync with KANTVUtils.java
+//add new AI benchmark type / new backend using GGML inference framework here, keep sync with KANTVAIUtils.java
 
 // available bench type for ggml-jni
 enum ggml_jni_bench_type {
@@ -113,9 +117,12 @@ enum ggml_jni_bench_type {
 
     int          llama_inference_main(int argc, char * argv[], int backend);
 
-    void         llama_init_running_state(void);
-    void         llama_reset_running_state(void);
-    int          llama_is_running_state(void);
+    /**
+     *helper functions to check whether AI inference is running, these helper functions is useful&necessary for UI in Java layer
+     */
+    void         inference_reset_running_state(void);
+    void         inference_reset_running_state(void);
+    int          inference_is_running_state(void);
 
     /**
     * multi-modal inference

--- a/core/ggml/jni/llm-inference.cpp
+++ b/core/ggml/jni/llm-inference.cpp
@@ -747,10 +747,10 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
                 max_tokens++;
 #if (defined __ANDROID__) || (defined ANDROID)
                 if (ggml_jni_is_valid_utf8(token_str.c_str())) {
-                    if (0 == llama_is_running_state()) {
+                    if (0 == inference_is_running_state()) {
                         llm_inference_interrupted = 1;
                     } else {
-                        kantv_asr_notify_benchmark_c(token_str.c_str());
+                        GGML_JNI_NOTIFY(token_str.c_str());
                     }
                 }
 #endif
@@ -965,18 +965,18 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
 #if 0  //dirty method to fix issue:https://github.com/zhouwg/kantv/issues/116, it seems not required from now on
         if (max_tokens > 300) {
 
-            kantv_asr_notify_benchmark_c("\n[end of text]\n\n");
+            GGML_JNI_NOTIFY("\n[end of text]\n\n");
             break;
         }
         int64_t end_duration = ggml_time_ms();
         if (end_duration - start_duration > 60000) {
-            kantv_asr_notify_benchmark_c("\n[end of text]\n\n");
+            GGML_JNI_NOTIFY("\n[end of text]\n\n");
             break;
         }
 #endif
 #endif
 
-        if (0 == llama_is_running_state()) {
+        if (0 == inference_is_running_state()) {
             llm_inference_interrupted = 1;
             break;
         }
@@ -984,7 +984,7 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
         if (!embd.empty() && llama_vocab_is_eog(vocab, embd.back()) && !(params.interactive)) {
             LOG(" [end of text]\n");
 #if (defined __ANDROID__) || (defined ANDROID)
-            kantv_asr_notify_benchmark_c("\n[end of text]\n\n");
+            GGML_JNI_NOTIFY("\n[end of text]\n\n");
 #endif
             break;
         }
@@ -1003,7 +1003,7 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
     }
 
     LOG("\n\n");
-    if (1 == llama_is_running_state()) {
+    if (1 == inference_is_running_state()) {
         llm_inference_interrupted = 0;
         common_perf_print(ctx, smpl);
     } else {
@@ -1018,7 +1018,7 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
     ggml_threadpool_free_fn(threadpool_batch);
 
     if (1 == llm_inference_interrupted)
-        return LLM_INFERENCE_INTERRUPTED;
+        return AI_INFERENCE_INTERRUPTED;
 
     return 0;
 }

--- a/core/ggml/jni/sd-inference.cpp
+++ b/core/ggml/jni/sd-inference.cpp
@@ -965,6 +965,9 @@ int sd_inference_main(int argc, const char* argv[], int backend_type) {
         LOGGD("Text2Image:width %d, height %d\n", params.width, params.height);
 #if (defined __ANDROID__) || (defined ANDROID)
         GGML_JNI_NOTIFY("Text2Image:width %d, height %d\n", params.width, params.height);
+        GGML_JNI_NOTIFY("pls waiting(don't stop StableDiffusion inference "
+                            "before the final generated image can be seen, otherwise unexpected behaviour would happen)...\n");
+
 #endif
         results = txt2img(sd_ctx,
                           params.prompt.c_str(),

--- a/core/ggml/llamacpp/ggml/src/ggml-hexagon/ggml-hexagon.cpp
+++ b/core/ggml/llamacpp/ggml/src/ggml-hexagon/ggml-hexagon.cpp
@@ -5195,6 +5195,8 @@ static int ggmlhexagon_init_rpcmempool(ggml_backend_hexagon_context * ctx) {
     if ((g_hexagon_appcfg.hwaccel_approach == HWACCEL_CDSP) && (1 == g_hexagon_appcfg.enable_rpc_ion_mempool)) {
         GGML_ASSERT(ctx->rpc_mempool_capacity > (8 * SIZE_IN_MB));
         ctx->rpc_mempool_len = ctx->rpc_mempool_capacity - (8 * SIZE_IN_MB);
+        //use rpcmem_alloc2 to alloc 2GiB memory, it's a workaround to make stablediffusion.cpp in Project KanTV happy
+        //because there are unknown issues with memory allocated by rpcmem_alloc2
         ctx->rpc_mempool = rpcmem_alloc2(RPCMEM_HEAP_ID_SYSTEM, RPCMEM_DEFAULT_FLAGS | RPCMEM_TRY_MAP_STATIC, ctx->rpc_mempool_len);
         if (nullptr == ctx->rpc_mempool) {
             GGMLHEXAGON_LOG_WARN("alloc rpc memorypool %ld(%d MiB) failed", ctx->rpc_mempool_len, ctx->rpc_mempool_capacity / SIZE_IN_MB);

--- a/core/ggml/llamacpp/src/llama-context.cpp
+++ b/core/ggml/llamacpp/src/llama-context.cpp
@@ -1285,6 +1285,12 @@ int llama_context::decode(llama_batch & inp_batch) {
 
         const auto & n_ubatch = cparams.n_ubatch;
 
+#if (defined __ANDROID__) || (defined ANDROID)
+        if (0 == inference_is_running_state()) {
+            return AI_INFERENCE_INTERRUPTED;
+        }
+#endif
+
         if (kv_self->recurrent) {
             if (embd_pooled) {
                 // Pooled embeddings cannot be split across ubatches (yet)

--- a/core/ggml/stablediffusioncpp/model.cpp
+++ b/core/ggml/stablediffusioncpp/model.cpp
@@ -18,6 +18,15 @@
 
 #include "stable-diffusion.h"
 
+#if defined(__ANDROID__) || defined(ANDROID)
+extern "C" {
+#include "libavutil/cde_log.h"
+#include "libavutil/cde_assert.h"
+}
+#include "ggml-jni.h"
+#include "llamacpp/ggml/include/ggml-hexagon.h"
+#endif
+
 #ifdef SD_USE_METAL
 #include "ggml-metal.h"
 #endif
@@ -1726,6 +1735,11 @@ bool ModelLoader::load_tensors(on_new_tensor_cb_t on_new_tensor_cb, ggml_backend
         std::string file_path = file_paths_[file_index];
         LOG_DEBUG("loading tensors from %s", file_path.c_str());
 
+#if (defined __ANDROID__) || (defined ANDROID)
+        GGML_JNI_NOTIFY("pls waiting(don't stop StableDiffusion inference "
+                        "before the final generated image can be seen, otherwise unexpected behaviour would happen)...\n");
+
+#endif
         std::ifstream file(file_path, std::ios::binary);
         if (!file.is_open()) {
             LOG_ERROR("failed to open '%s'", file_path.c_str());

--- a/core/ggml/stablediffusioncpp/stable-diffusion.cpp
+++ b/core/ggml/stablediffusioncpp/stable-diffusion.cpp
@@ -1450,6 +1450,12 @@ sd_image_t* generate_image(sd_ctx_t* sd_ctx,
         int64_t sampling_start = ggml_time_ms();
         int64_t cur_seed       = seed + b;
         LOG_INFO("generating image: %i/%i - seed %" PRId64, b + 1, batch_count, cur_seed);
+#if (defined __ANDROID__) || (defined ANDROID)
+        if (0 == inference_is_running_state()) {
+            ggml_free(work_ctx);
+            return NULL;
+        }
+#endif
 
         sd_ctx->sd->rng->manual_seed(cur_seed);
         struct ggml_tensor* x_t   = init_latent;

--- a/core/ggml/stablediffusioncpp/util.cpp
+++ b/core/ggml/stablediffusioncpp/util.cpp
@@ -424,8 +424,9 @@ void log_printf(sd_log_level_t level, const char* file, int line, const char* fo
     if (sd_log_cb) {
         sd_log_cb(level, log_buffer, sd_log_cb_data);
     }
-
+#if defined(__ANDROID__) || defined(ANDROID)
     GGML_JNI_NOTIFY("%s", log_buffer);
+#endif
 
     va_end(args);
 }

--- a/docs/acknowledgement.md
+++ b/docs/acknowledgement.md
@@ -30,6 +30,7 @@ Project KanTV has used/tried following open-source projects(list in here is inco
      <li><a href="https://webrtc.github.io/webrtc-org/start/" target="_blank" rel="noopener">WebRTC</a></li>
      <li><a href="https://github.com/shaka-project/shaka-packager" target="_blank" rel="noopener">Google ShakaPackager</a></li>
      <li><a href="https://github.com/ossrs/srs" target="_blank" rel="noopener">SRS</a></li>
+     <li><a href="https://github.com/begeekmyfriend/yasea" target="_blank" rel="noopener">yasea</a></li>
      <li><a href="https://github.com/nihui/ruapu" target="_blank" rel="noopener">RUAPU</a></li>
      <li>......</li>
 </ul>


### PR DESCRIPTION
### Purpose
- refine JNI and make function names and codes and comments more clear
- refine KANTVUtils.java and KANTVAIUtils.java: move AI related functions from KANTVUtils.java to KANTVAIUtils.java
- try to improve stability of llava inference and stablediffusion inference in some corner cases: toggle back and forth frequently between different UI or start/stop AI inference between different inference type(LLM, LLAVA, StableDiffusion). there still stability issue in some corner cases and need to understand the data path in llava inference and StableDiffusion inference more clear.
- refine the location of the default/built-in ASR model and make user experience more better(avoid "ASR subsystem is not initialized" or "ASR initialization failure" when launch the APK at the first time).
- refine some docs and make doc more clear.