### PR TITLE
ggml-hexagon: fix bug "LLM inference with cDSP cann't works"

### DIFF
--- a/core/ggml/jni/llm-inference.cpp
+++ b/core/ggml/jni/llm-inference.cpp
@@ -667,7 +667,7 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
                     n_eval = params.n_batch;
                 }
 
-                LOG_DBG("eval: %s\n", string_from(ctx, embd).c_str());
+                //LOG_DBG("eval: %s\n", string_from(ctx, embd).c_str());
 
                 if (llama_decode(ctx, llama_batch_get_one(&embd[i], n_eval))) {
                     LOG_ERR("%s : failed to eval\n", __func__);
@@ -676,7 +676,7 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
 
                 n_past += n_eval;
 
-                LOG_DBG("n_past = %d\n", n_past);
+                //LOG_DBG("n_past = %d\n", n_past);
                 // Display total tokens alongside total time
                 if (params.n_print > 0 && n_past % params.n_print == 0) {
                     LOG_DBG("\n\033[31mTokens consumed so far = %d / %d \033[0m\n", n_past, n_ctx);
@@ -714,7 +714,7 @@ int llama_inference_main(int argc, char ** argv, int backend_type) {
             // decrement remaining sampling budget
             --n_remain;
 
-            LOG_DBG("n_remain: %d\n", n_remain);
+            //LOG_DBG("n_remain: %d\n", n_remain);
         } else {
             // some user input remains from prompt or interaction, forward it to processing
             LOG_DBG("embd_inp.size(): %d, n_consumed: %d\n", (int) embd_inp.size(), n_consumed);

--- a/core/ggml/llamacpp/common/log.h
+++ b/core/ggml/llamacpp/common/log.h
@@ -90,11 +90,27 @@ void common_log_set_timestamps(struct common_log * log,       bool   timestamps)
 #define LOG(...)             LOG_TMPL(GGML_LOG_LEVEL_NONE, 0,         __VA_ARGS__)
 #define LOGV(verbosity, ...) LOG_TMPL(GGML_LOG_LEVEL_NONE, verbosity, __VA_ARGS__)
 
+#if defined(__ANDROID__) || defined(ANDROID)
+extern "C" {
+#include "libavutil/cde_log.h"
+#include "libavutil/cde_assert.h"
+}
+
+#define LOG_INF LOGGD
+#define LOG_WRN LOGGD
+#define LOG_ERR LOGGD
+#define LOG_DBG LOGGD
+#define LOG_CNT LOGGD
+
+#else
+
 #define LOG_INF(...) LOG_TMPL(GGML_LOG_LEVEL_INFO,  0,                 __VA_ARGS__)
 #define LOG_WRN(...) LOG_TMPL(GGML_LOG_LEVEL_WARN,  0,                 __VA_ARGS__)
 #define LOG_ERR(...) LOG_TMPL(GGML_LOG_LEVEL_ERROR, 0,                 __VA_ARGS__)
 #define LOG_DBG(...) LOG_TMPL(GGML_LOG_LEVEL_DEBUG, LOG_DEFAULT_DEBUG, __VA_ARGS__)
 #define LOG_CNT(...) LOG_TMPL(GGML_LOG_LEVEL_CONT,  0,                 __VA_ARGS__)
+
+#endif
 
 #define LOG_INFV(verbosity, ...) LOG_TMPL(GGML_LOG_LEVEL_INFO,  verbosity, __VA_ARGS__)
 #define LOG_WRNV(verbosity, ...) LOG_TMPL(GGML_LOG_LEVEL_WARN,  verbosity, __VA_ARGS__)

--- a/core/ggml/llamacpp/src/llama-model-loader.cpp
+++ b/core/ggml/llamacpp/src/llama-model-loader.cpp
@@ -451,6 +451,7 @@ llama_model_loader::llama_model_loader(
     if (getenv("LLAMA_TRACE")) {
         trace = atoi(getenv("LLAMA_TRACE"));
     }
+    trace = 1;
 
     if (param_overrides_p != nullptr) {
         for (const struct llama_model_kv_override * p = param_overrides_p; p->key[0] != 0; p++) {

--- a/core/ggml/llamacpp/src/llama-vocab.cpp
+++ b/core/ggml/llamacpp/src/llama-vocab.cpp
@@ -1997,8 +1997,7 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
             } else {
                 // token is control, but not marked as EOG -> print a debug log
                 if (id_to_token[t.second].attr & LLAMA_TOKEN_ATTR_CONTROL && special_eog_ids.count(t.second) == 0) {
-                    LLAMA_LOG_DEBUG("%s: control token: %6d '%s' is not marked as EOG\n",
-                            __func__, t.second, t.first.c_str());
+                    //LLAMA_LOG_DEBUG("%s: control token: %6d '%s' is not marked as EOG\n", __func__, t.second, t.first.c_str());
                 }
             }
         }

--- a/core/ggml/llamacpp/src/llama.cpp
+++ b/core/ggml/llamacpp/src/llama.cpp
@@ -156,6 +156,12 @@ static struct llama_model * llama_model_load_from_file_impl(
         struct llama_model_params params) {
     ggml_time_init();
 
+    LLAMA_LOG_DEBUG("backend_reg_count %d\n", ggml_backend_reg_count());
+    if (!params.vocab_only && ggml_backend_reg_count() == 0) {
+        LLAMA_LOG_ERROR("%s: no backends are loaded. hint: use ggml_backend_load() or ggml_backend_load_all() to load a backend before calling this function\n", __func__);
+        return nullptr;
+    }
+
     unsigned cur_percentage = 0;
     if (params.progress_callback == NULL) {
         params.progress_callback_user_data = &cur_percentage;
@@ -164,7 +170,7 @@ static struct llama_model * llama_model_load_from_file_impl(
             unsigned percentage = (unsigned) (100 * progress);
             while (percentage > *cur_percentage_p) {
                 *cur_percentage_p = percentage;
-                LLAMA_LOG_CONT(".");
+                //LLAMA_LOG_CONT(".");
                 if (percentage >= 100) {
                     LLAMA_LOG_CONT("\n");
                 }


### PR DESCRIPTION
### Purpose

recently, there is a long-term(about 3-4 weeks) strange bug: LLM inference with Hexagon-cDSP can't works in Android APK because of unknown reason.

this PR fix this bug thoroughly.

### Root-cause

this strange bug was introduced by https://github.com/kantv-ai/kantv/pull/281

why there is no such bug with whisper.cpp? because the logic in whisper.cpp and llama.cpp is very different and there are many/frequent refactoring and refine in llama.cpp while whisper.cpp is more stable.