### PR TITLE
java: support download AI models from hf-mirror.com

### DIFF
--- a/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIModelMgr.java
+++ b/android/kantvplayer-lib/src/main/java/kantvai/ai/KANTVAIModelMgr.java
@@ -3,6 +3,8 @@
  */
 package kantvai.ai;
 
+import java.util.Locale;
+
 import kantvai.media.player.KANTVLibraryLoader;
 import kantvai.media.player.KANTVLog;
 
@@ -186,7 +188,15 @@ public class KANTVAIModelMgr {
 
      //how to convert safetensors to GGUF and quantize LLM model:https://www.kantvai.com/posts/Convert-safetensors-to-gguf.html
      private void initAIModels() {
+         String hf_endpoint = "https://huggingface.co/";
          KANTVLog.g(TAG, "init AI Models");
+         Locale local = Locale.getDefault();
+         String language = local.getLanguage();
+         KANTVLog.g(TAG, "language " + language);
+         if (language.equals("zh")) {
+             hf_endpoint = "https://hf-mirror.com/";
+         }
+
          try {
              KANTVLibraryLoader.load("ggml-jni");
              KANTVLog.g(TAG, "cpu core counts:" + ggmljava.get_cpu_core_counts());
@@ -207,80 +217,70 @@ public class KANTVAIModelMgr {
          arrayBenchType[4] = "Text2Image";
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_ASR, "tiny.en-q8_0", "ggml-tiny.en-q8_0.bin",
-                 "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-tiny.en-q8_0.bin",
+                 hf_endpoint + "ggerganov/whisper.cpp/resolve/main/ggml-tiny.en-q8_0.bin",
                  43550795 //the built-in and default ASR model, size is 42 MiB
          );
          //there are only one Whisper model currently
          AIModels[0].setSample("jfk.wav", 43550795,
-                 "https://huggingface.co/datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav");
+                 hf_endpoint + "datasets/Xenova/transformers.js-docs/resolve/main/jfk.wav");
 
 
          //there are only one StableDiffusion model currently
          addAIModel(KANTVAIModel.AIModelType.TYPE_TEXT2IMAGE, "sd-v1.4", "sd-v1-4.ckpt",
-                 "https://huggingface.co/CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt",
+                 hf_endpoint + "CompVis/stable-diffusion-v-1-4-original/resolve/main/sd-v1-4.ckpt",
                  4265380512L); // size of the StableDiffusion model, about 4.0 GiB
 
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Qwen1.5-1.8B", "qwen1_5-1_8b-chat-q4_0.gguf",
-                 "https://huggingface.co/Qwen/Qwen1.5-1.8B-Chat-GGUF/resolve/main/qwen1_5-1_8b-chat-q4_0.gguf?download=true",
-                 (long)(1.12 * 1024 * 1024 * 1024L)
+                 hf_endpoint + "Qwen/Qwen1.5-1.8B-Chat-GGUF/resolve/main/qwen1_5-1_8b-chat-q4_0.gguf?download=true",
+                 1120235360L
                  );
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Qwen2.5-3B", "qwen2.5-3b-instruct-q4_0.gguf",
-                 "https://huggingface.co/Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/main/qwen2.5-3b-instruct-q4_0.gguf?download=true",
-                 (long)(2 * 1024 * 1024 * 1024)
+                 hf_endpoint + "Qwen/Qwen2.5-3B-Instruct-GGUF/resolve/main/qwen2.5-3b-instruct-q4_0.gguf?download=true",
+                 1997879712L
                  );
 
-
-         addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Qwen2.5-VL-3B",
-                 "Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf", "mmproj-Qwen2.5-VL-3B-Instruct-Q8_0.gguf",
-                 "https://huggingface.co/ggml-org/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/Qwen2.5-VL-3B-Instruct-Q4_K_M.gguf?download=true",
-                 "https://huggingface.co/ggml-org/Qwen2.5-VL-3B-Instruct-GGUF/resolve/main/mmproj-Qwen2.5-VL-3B-Instruct-Q8_0.gguf?download=true",
-                 (long)(1.93 * 1024 * 1024 * 1024L),
-                 845 * 1024 * 1024L
-         );
-
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Qwen3-4B", "Qwen3-4B-Q8_0.gguf",
-                 "https://huggingface.co/ggml-org/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q8_0.gguf?download=true",
+                 hf_endpoint + "ggml-org/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q8_0.gguf?download=true",
                  4280404640L);
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Qwen3-8B", "Qwen3-8B-Q8_0.gguf",
-                 "https://huggingface.co/ggml-org/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q8_0.gguf?download=true",
-                 (long)(8.71 * 1024 * 1024 * 1024L));
+                 hf_endpoint + "ggml-org/Qwen3-8B-GGUF/resolve/main/Qwen3-8B-Q8_0.gguf?download=true",
+                 8709518464L);
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Qwen3-14B", "Qwen3-14B-Q4_K_M.gguf",
-                 "https://huggingface.co/Qwen/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf?download=true",
-                 (long)(9 * 1024 * 1024 * 1024L));
+                 hf_endpoint + "Qwen/Qwen3-14B-GGUF/resolve/main/Qwen3-14B-Q4_K_M.gguf?download=true",
+                 9001752960L);
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Gemma3-4B", "gemma-3-4b-it-Q8_0.gguf", "mmproj-gemma3-4b-f16.gguf",
-                 "https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q8_0.gguf?download=true",
-                 "https://huggingface.co/ggml-org/gemma-3-4b-it-GGUF/resolve/main/mmproj-model-f16.gguf?download=true",
+                 hf_endpoint + "ggml-org/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q8_0.gguf?download=true",
+                 hf_endpoint + "ggml-org/gemma-3-4b-it-GGUF/resolve/main/mmproj-model-f16.gguf?download=true",
                  4130226336L,//size of the main model in bytes, 4.13 GiB
                  851251104L //size of the mmproj model in bytes, 851 MiB
          );
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "Gemma3-12B", "gemma-3-12b-it-Q4_K_M.gguf", "mmproj-gemma3-12b-f16.gguf",
-                 "https://huggingface.co/ggml-org/gemma-3-12b-it-GGUF/resolve/main/gemma-3-12b-it-Q4_K_M.gguf?download=true",
-                 "https://huggingface.co/ggml-org/gemma-3-12b-it-GGUF/resolve/main/mmproj-model-f16.gguf?download=true",
+                 hf_endpoint + "ggml-org/gemma-3-12b-it-GGUF/resolve/main/gemma-3-12b-it-Q4_K_M.gguf?download=true",
+                 hf_endpoint + "ggml-org/gemma-3-12b-it-GGUF/resolve/main/mmproj-model-f16.gguf?download=true",
                  7300574976L,
                  854200224L
          );
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "SmolVLM-500M", "SmolVLM-500M-Instruct-f16.gguf", "mmproj-SmolVLM-500M-Instruct-f16.gguf",
-                 "https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/SmolVLM-500M-Instruct-f16.gguf?download=true",
-                 "https://huggingface.co/ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/mmproj-SmolVLM-500M-Instruct-f16.gguf?download=true",
+                 hf_endpoint + "ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/SmolVLM-500M-Instruct-f16.gguf?download=true",
+                 hf_endpoint + "ggml-org/SmolVLM-500M-Instruct-GGUF/resolve/main/mmproj-SmolVLM-500M-Instruct-f16.gguf?download=true",
                  820422912L,
                  199468800L
          );
 
          addAIModel(KANTVAIModel.AIModelType.TYPE_LLM, "SmolVLM2-256M",
                  "SmolVLM2-256M-Video-Instruct-f16.gguf", "mmproj-SmolVLM2-256M-Video-Instruct-f16.gguf",
-                 "https://huggingface.com/ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/resolve/main/SmolVLM2-256M-Video-Instruct-f16.gguf?download=true",
-                 "https://huggingface.com/ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-256M-Video-Instruct-f16.gguf?download=true",
+                 hf_endpoint + "ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/resolve/main/SmolVLM2-256M-Video-Instruct-f16.gguf?download=true",
+                 hf_endpoint + "ggml-org/SmolVLM2-256M-Video-Instruct-GGUF/resolve/main/mmproj-SmolVLM2-256M-Video-Instruct-f16.gguf?download=true",
                  327811552L,
                  190033440L
          );
-
 
          modelCounts = modelIndex;  //modelCounts is real counts of all AI models
          //initialize arrayModeName for UI AIResearchFragment.java to display all AI models(1 ASR model + all LLM models + others)


### PR DESCRIPTION
### Purpose

as well known, users/developers from mainland China can't directly access the https://huggingface.co/ at the moment.

this PR support download AI models from hf-mirror.com for users/developers from mainland China.

this is a workaround approach because I don't whether the hf-mirror.com is stable?